### PR TITLE
Have PV report total space as the size.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -625,6 +625,7 @@
     "k8s.io/api/storage/v1",
     "k8s.io/api/storage/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/uuid",


### PR DESCRIPTION
Instead of reporting the PVC request size as the PV size, use the total space of the directory we are writing in instead. Since there is nothing stopping pods from writing outside of the size they requested and in theory they can consume the entire directory space, it makes sense to report the PV at that size.

Signed-off-by: Alexander Wels <awels@redhat.com>