### PR TITLE
Add hostpath-provisioner to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _out/*
 **/*.swp
 .vscode
+hostpath-provisioner


### PR DESCRIPTION
In case someone (like me) runs `go build/go test` and gets a binary
artifact in the root directory, don't accidentally add it to the
repo.