### PR TITLE
Add test directive to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ IMAGE?=hostpath-provisioner
 all: dep controller hostpath-provisioner image push
 
 dep:
-	-dep init
-	dep ensure
+	dep check  # use `dep ensure -add xxxxx` for any missing packages
 
 controller:
 	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' controller
@@ -35,3 +34,6 @@ clean:
 	rm -rf vendor
 	rm -rf Gopkg.lock
 	rm -rf hostpath-provisioner
+build: clean dep controller hostpath-provisioner
+test:
+	go test -v ./...


### PR DESCRIPTION
Add a `test` directive to the Makefile to run unit tests.  Also rework
dep arguments, don't run `init` or `ensure` becuase this will update all
the things every time.  Instead, just run check and leave it to the user
to add new packages as necessary.