### PR TITLE
Add travis job to run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go_import_path: kubevirt.io/hostpath-provisioner
+go:
+  - 1.11.5
+before_install:
+  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  - make dep
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 IMAGE?=hostpath-provisioner
 
-all: dep controller hostpath-provisioner image push
+all: dep controller hostpath-provisioner
 
 dep:
 	dep check  # use `dep ensure -add xxxxx` for any missing packages
@@ -30,10 +30,11 @@ image: hostpath-provisioner
 
 push: hostpath-provisioner image
 	docker push $(IMAGE)
+
 clean:
-	rm -rf vendor
-	rm -rf Gopkg.lock
-	rm -rf hostpath-provisioner
+	rm -rf _out
+
 build: clean dep controller hostpath-provisioner
+
 test:
 	go test -v ./...


### PR DESCRIPTION
This PR just adds a base travis job that will ensure the PR builds and
passes unit tests.  Follow up will include auto-publish and linting
checks.