### PR TITLE
Support Binding Mode WaitForFirstConsumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@ A special multi-node version of the kubernetes hostpath provisioner.
 
 ## Overview
 
-This is a special version of the kubernetes hostpath provisioner, it's a slightly modified version of the sig storage [example hostpath prvisioner](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/tree/master/examples/hostpath-provisioner).
+This is a special version of the kubernetes hostpath provisioner, it's a slightly modified version of the sig storage [example hostpath provisioner](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/tree/master/examples/hostpath-provisioner).
 
 ## Differences
 
 The main differences between this provisioner and the standard hostpath provisioner you may already be familiar with are:
 1. Ability to specify the base directory to use on the node(s) for the volume - `PV_DIR`
 2. This provisioner is a "node aware" provisioner, in order to provision a claim using this provisioner you must include a node attribute on the claim `kubevirt.io/provisionOnNode: node-01`
+3. Or if you do not want to specify the node on the claim, you can specify `volumeBindingMode: WaitForFirstConsumer` in the storage class. Then the PV will be created only when the first Pod using this PVC is scheduled. The PV will be created on the node that the Pod is scheduled on.
+Still, the annotation `kubevirt.io/provisionOnNode` can be used in this mode, though it will not wait for the first consumer.
 
 ## Deployment
 
-The provisioner is deployed as a daemonset, and instance of the provisioner is deployed to each of the worker nodes in the kubernetes cluster.  We then disable the use of leader election so that any provisioning request is issues to all of the provsioners in the cluster.  Each provisioner then evaluates the provision request based on the Node attribute by filtering out any requests that don't match the Node name for the provisioner pod.
+The provisioner is deployed as a daemonset, and instance of the provisioner is deployed to each of the worker nodes in the kubernetes cluster. We then disable the use of leader election so that any provisioning request is issues to all of the provisioners in the cluster. Each provisioner then evaluates the provision request based on the Node attribute by filtering out any requests that don't match the Node name for the provisioner pod. In case of `WaitForFirstConsumer` binding mode, the provision request is ignored by all the provisioners until a consumer (Pod) is scheduled. Then, an annotation `volume.kubernetes.io/selected-node` containing the node name where the pod is scheduled on, will be added to the PVC. The provisioners will check if the annotation matches the node it runs on, and only if there is a match the PV will be created.
 
 ### Deployment in OpenShift
 In order to deploy this provisioner in OpenShift you will need to supply the correct SecurityContextConstraints. A minimal needed one is supplied in the [deploy](./deploy) directory. You will also have to create the appropriate selinux rules to allow the pod to write to the path on the host. Our examples use /var/hpvolumes as the path on the host, if you have modified the path change it for this command as well.

--- a/controller/volume.go
+++ b/controller/volume.go
@@ -45,7 +45,7 @@ type Provisioner interface {
 type Qualifier interface {
 	// ShouldProvision returns whether provisioning for the claim should
 	// be attempted.
-	ShouldProvision(*v1.PersistentVolumeClaim) bool
+	ShouldProvision(*v1.PersistentVolumeClaim, *storageapis.VolumeBindingMode) bool
 }
 
 // DeletionGuard is an optional interface implemented by provisioners to determine

--- a/deploy/kubevirt-hostpath-provisioner.yaml
+++ b/deploy/kubevirt-hostpath-provisioner.yaml
@@ -29,9 +29,11 @@ metadata:
   name: kubevirt-hostpath-provisioner
 rules:
   - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete"]
-
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]


### PR DESCRIPTION
In order to be able to use the hostpath-provisioner without specifying
the node on the PVC, support for WaitForFirstConsumer is needed.

In case that the storage class is defined with volumeBindingMode:
WaitForFirstConsumer, the PV will not be created until a Pod is
scheduled to run.

Signed-off-by: Fred Rolland <frolland@redhat.com>
Signed-off-by: Daniel Erez <derez@redhat.com>