### PR TITLE
Updated the sync and clean to use new operator image strings

### DIFF
--- a/cluster-sync/clean.sh
+++ b/cluster-sync/clean.sh
@@ -25,3 +25,4 @@ fi
 
 _kubectl delete -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/master/deploy/operator.yaml -n hostpath-provisioner --ignore-not-found
 _kubectl delete -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/master/deploy/namespace.yaml --ignore-not-found
+_kubectl delete -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/master/deploy/storageclass-wffc.yaml --ignore-not-found


### PR DESCRIPTION
Updated the sync logic to pass the entire hostpath provisioner image, the operator no longer constructs the image name from the repo/image name/tag.
```release-note
Operator now uses fill image as container name for host path provisioner.
```
Signed-off-by: Alexander Wels <awels@redhat.com>