### PR TITLE
Update API group for DaemonSet to use apps group

### DIFF
--- a/deploy/kubevirt-hostpath-provisioner.yaml
+++ b/deploy/kubevirt-hostpath-provisioner.yaml
@@ -52,7 +52,7 @@ metadata:
   name: kubevirt-hostpath-provisioner-admin
   namespace: kubevirt-hostpath-provisioner
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kubevirt-hostpath-provisioner


### PR DESCRIPTION
The extension group was removed in kubernetes 1.16
and replaced by the apps group. This patch just updates
the deployment manifest to use the new apps group and
should maintain backward compatibility for older versions.

Sure, the operator works, but I'm not using it so thought why not fix it here.

Fixes #36 


```release-note
None
```
Signed-off-by: John Griffith <john.griffith8@gmail.com>
