### PR TITLE
HPP only supports ReadWriteOnce, don't just copy the PVC request.

### DIFF
--- a/cmd/provisioner/hostpath-provisioner.go
+++ b/cmd/provisioner/hostpath-provisioner.go
@@ -160,7 +160,9 @@ func (p *hostPathProvisioner) Provision(options controller.ProvisionOptions) (*v
 			},
 			Spec: v1.PersistentVolumeSpec{
 				PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
-				AccessModes:                   options.PVC.Spec.AccessModes,
+				AccessModes: []v1.PersistentVolumeAccessMode{
+					v1.ReadWriteOnce,
+				},
 				Capacity: v1.ResourceList{
 					v1.ResourceName(v1.ResourceStorage): *pvCapacity,
 				},


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It was possible to create a RWX PV, which is not supported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Remove ability to accidentally create RWX PV.
```

