### PR TITLE
Add functonal test to ensure hostpath provisioner CRD is explainable.

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -45,3 +45,23 @@ func TestOperatorEventsReconcileChange(t *testing.T) {
 		return out
 	}, 90*time.Second, 1*time.Second).Should(ContainSubstring("UpdateResourceSuccess"))
 }
+
+func TestCRDExplainable(t *testing.T) {
+	RegisterTestingT(t)
+
+	// This test doesn't test all the fields exhaustively. It checks the top level, and some others to ensure
+	// the explain works in general.
+	// Test top level fields
+	out, err := RunKubeCtlCommand("explain", "hostpathprovisioner")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(out).To(ContainSubstring("HostPathProvisionerSpec defines the desired state of HostPathProvisioner"))
+	Expect(out).To(ContainSubstring("HostPathProvisionerStatus defines the observed state of HostPathProvisioner"))
+
+	// Test status fields
+	out, err = RunKubeCtlCommand("explain", "hostpathprovisioner.status")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(out).To(ContainSubstring("Conditions contains the current conditions observed by the operator"))
+	Expect(out).To(ContainSubstring("ObservedVersion The observed version of the HostPathProvisioner deployment"))
+	Expect(out).To(ContainSubstring("OperatorVersion The version of the HostPathProvisioner Operator"))
+	Expect(out).To(ContainSubstring("TargetVersion The targeted version of the HostPathProvisioner deployment"))
+}


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

