### PR TITLE
Allow the name of the provisioner to be be configured with PROVISIONER_NAME environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a special version of the kubernetes hostpath provisioner, it's a slightl
 
 The main differences between this provisioner and the standard hostpath provisioner you may already be familiar with are:
 1. Ability to specify the base directory to use on the node(s) for the volume - `PV_DIR`
+2. Ability to specify the name of the name of the provisioner registered with Kubernetes - `PROVISIONER_NAME`
 2. This provisioner is a "node aware" provisioner, in order to provision a claim using this provisioner you must include a node attribute on the claim `kubevirt.io/provisionOnNode: node-01`
 3. Or if you do not want to specify the node on the claim, you can specify `volumeBindingMode: WaitForFirstConsumer` in the storage class. Then the PV will be created only when the first Pod using this PVC is scheduled. The PV will be created on the node that the Pod is scheduled on.
 Still, the annotation `kubevirt.io/provisionOnNode` can be used in this mode, though it will not wait for the first consumer.
@@ -21,6 +22,8 @@ _In cases where multiple PVCs are to be used with a Pod it is not recommended to
 The provisioner is deployed as a daemonset, and instance of the provisioner is deployed to each of the worker nodes in the kubernetes cluster. We then disable the use of leader election so that any provisioning request is issues to all of the provisioners in the cluster. Each provisioner then evaluates the provision request based on the Node attribute by filtering out any requests that don't match the Node name for the provisioner pod. In case of `WaitForFirstConsumer` binding mode, the provision request is ignored by all the provisioners until a consumer (Pod) is scheduled. Then, an annotation `volume.kubernetes.io/selected-node` containing the node name where the pod is scheduled on, will be added to the PVC. The provisioners will check if the annotation matches the node it runs on, and only if there is a match the PV will be created.
 
 *WARNING* If you select a directory that shares space with your Operating System, you can potentially exhaust the space on that partition and your node will become non-functional. It is recommended you create a separate partition and point the hostpath provisioner there so it will not interfere with your Operating System
+
+*WARNING* If the name of the provisioner is customized with `PROVISIONER_NAME` ensure the storage class's `provisioner` field is also updated.
 
 ### Deployment in OpenShift
 In order to deploy this provisioner in OpenShift you will need to supply the correct SecurityContextConstraints. A minimal needed one is supplied in the [deploy](./deploy) directory. You will also have to create the appropriate selinux rules to allow the pod to write to the path on the host. Our examples use /var/hpvolumes as the path on the host, if you have modified the path change it for this command as well.

--- a/cmd/provisioner/hostpath-provisioner_test.go
+++ b/cmd/provisioner/hostpath-provisioner_test.go
@@ -177,7 +177,7 @@ func Test_isCorrectNodeByBindingMode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isCorrectNodeByBindingMode(tt.args.annotations, tt.args.nodeName, tt.args.bindingMode); got != tt.want {
+			if got := isCorrectNodeByBindingMode(tt.args.annotations, tt.args.nodeName, defaultProvisionerName, tt.args.bindingMode); got != tt.want {
 				t.Errorf("isCorrectNodeByBindingMode() = %v, want %v", got, tt.want)
 			}
 		})

--- a/deploy/kubevirt-hostpath-provisioner.yaml
+++ b/deploy/kubevirt-hostpath-provisioner.yaml
@@ -82,6 +82,10 @@ spec:
                   fieldPath: spec.nodeName
             - name: PV_DIR
               value: /var/hpvolumes
+            # change to override the name of the registered provisioner. 
+            # if this changed the storage class's 'provisioner' also has to be updated.
+            - name: PROVISIONER_NAME
+              value: kubevirt.io/hostpath-provisioner
           volumeMounts:
             - name: pv-volume # root dir where your bind mounts will be on the node
               mountPath: /var/hpvolumes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
**What this PR does**:
- Allows the name of the provisioner to be configured with `PROVISIONER_NAME` environment variable
- Reverts to `kubevirt.io/hostpath-provisioner` if unset.

**Why we need it**:
- Allowing the name of the provisioned is useful for running multiple storage classes:
     -  ie one storage class for slow hard disk storage/one for fast SSD  storage
     -  Allows us to tie the different storage class to different provisioner deployments (with different `PV_DIR`).
- Currently name of provisioner is hardcoded.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added PROVISIONER_NAME environment variable to allow the name of the hostpath provisioner to be configured.
```

