### PR TITLE
Build using the vendored dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ ARTIFACTS_PATH?=_out
 all: controller hostpath-provisioner
 
 controller:
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' controller
+	CGO_ENABLED=0 go build -mod=vendor -a -ldflags '-extldflags "-static"' controller
 
 hostpath-provisioner: controller
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go
+	CGO_ENABLED=0 go build -mod=vendor -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go
 
 image: hostpath-provisioner
 	docker build -t $(DOCKER_REPO)/$(HPP_IMAGE):$(TAG) -f Dockerfile .


### PR DESCRIPTION
**What this PR does / why we need it**:
I mostly added this so I won't have to deal with this error:
`	github.com/spf13/pflag@v1.0.5: reading github.com/spf13/pflag/go.mod at revision v1.0.5: unknown revision v1.0.5`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

