### PR TITLE
Use same name in examples/claim.yaml as in deploy/kubevirt-hostpath-provisioner.yaml

### DIFF
--- a/examples/claim.yaml
+++ b/examples/claim.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations: 
     kubevirt.io/provisionOnNode: kube-1
 spec:
-  storageClassName: "kubevirt-hpp"
+  storageClassName: "kubevirt-hostpath-provisioner"
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Easier for user to test out this library if the storage class name is consistent between deploy manifest and example claim manifest.

Noticed this difference myself after running the example manifests in a cluster and receiving a "storage class 'kubevirt-hpp' not found" error.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

