### PR TITLE
Fix build make target referencing invalid target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ push-csi: hostpath-provisioner-plugin image-csi
 clean:
 	rm -rf _out
 
-build: clean hostpath-provisioner hostpath-provisioner-csi
+build: clean hostpath-provisioner hostpath-provisioner-plugin
 
 cluster-up:
 	KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./cluster-up/up.sh


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Point to the right make target with make build.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #75

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

