### PR TITLE
Update build to use PROW golang container in ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,15 @@ HPP_IMAGE?=hostpath-provisioner
 TAG?=latest
 DOCKER_REPO?=kubevirt
 ARTIFACTS_PATH?=_out
+GOLANG_VER?=1.16.8
 
 all: controller hostpath-provisioner
 
 hostpath-provisioner:
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go
+	GOLANG_VER=${GOLANG_VER} ./hack/build-provisioner.sh
 
 hostpath-provisioner-plugin:
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner-csi cmd/plugin/plugin.go
+	GOLANG_VER=${GOLANG_VER} ./hack/build-csi.sh
 
 image: image-controller image-csi
 
@@ -62,7 +63,7 @@ cluster-clean:
 	KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./cluster-sync/clean.sh
 
 test:
-	./hack/run-unit-test.sh
+	GOLANG_VER=${GOLANG_VER} ./hack/run-unit-test.sh
 
 test-functional:
 	KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} gotestsum --format short-verbose --junitfile ${ARTIFACTS_PATH}/junit.functest.xml -- ./tests/... -master="" -kubeconfig="../_ci-configs/$(KUBEVIRT_PROVIDER)/.kubeconfig"

--- a/hack/build-csi.sh
+++ b/hack/build-csi.sh
@@ -13,7 +13,6 @@
 #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #See the License for the specific language governing permissions and
 #limitations under the License.
-set -e
 
 if [[ -v PROW_JOB_ID ]] ; then
   GOLANG_VER=${GOLANG_VER:-1.16.8}
@@ -21,13 +20,6 @@ if [[ -v PROW_JOB_ID ]] ; then
   chown prow:prow -R /home/prow
   eval $(gimme ${GOLANG_VER})
   cp -R /root/.gimme/versions/${GOLANG_VER}.linux.amd64 /usr/local/go
-  echo "Run go test -v in $PWD"
-  sudo -i -u prow /bin/bash -c 'cd /home/prow/go/src/github.com/kubevirt/hostpath-provisioner && /usr/local/go/bin/go test -v ./cmd/... ./controller/... ./pkg/...'
-  go get -u golang.org/x/lint/golint
-else
-  echo "Run go test -v in $PWD"
-  # Run test
-  go test -v ./cmd/... ./controller/... ./pkg/...
 fi
 
-hack/run-lint-checks.sh
+CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner-csi cmd/plugin/plugin.go

--- a/hack/build-provisioner.sh
+++ b/hack/build-provisioner.sh
@@ -13,7 +13,6 @@
 #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #See the License for the specific language governing permissions and
 #limitations under the License.
-set -e
 
 if [[ -v PROW_JOB_ID ]] ; then
   GOLANG_VER=${GOLANG_VER:-1.16.8}
@@ -21,13 +20,6 @@ if [[ -v PROW_JOB_ID ]] ; then
   chown prow:prow -R /home/prow
   eval $(gimme ${GOLANG_VER})
   cp -R /root/.gimme/versions/${GOLANG_VER}.linux.amd64 /usr/local/go
-  echo "Run go test -v in $PWD"
-  sudo -i -u prow /bin/bash -c 'cd /home/prow/go/src/github.com/kubevirt/hostpath-provisioner && /usr/local/go/bin/go test -v ./cmd/... ./controller/... ./pkg/...'
-  go get -u golang.org/x/lint/golint
-else
-  echo "Run go test -v in $PWD"
-  # Run test
-  go test -v ./cmd/... ./controller/... ./pkg/...
 fi
 
-hack/run-lint-checks.sh
+CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+#Copyright 2021 The hostpath provisioner operator Authors.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
 set -exuo pipefail
 
 function cleanup_gh_install() {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The release scripts assumed that go exists in the build pipeline, but in PROW this is not always the case. I created https://github.com/kubevirt/project-infra/pull/1625 to use the build in go containers and this PR will set the wanted version, and run the build with it.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

