### PR TITLE
Update build to use PROW golang container in ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,15 @@ HPP_IMAGE?=hostpath-provisioner
 TAG?=latest
 DOCKER_REPO?=kubevirt
 ARTIFACTS_PATH?=_out
+GOLANG_VER?=1.16.8
 
 all: controller hostpath-provisioner
 
 hostpath-provisioner:
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go
+	GOLANG_VER=${GOLANG_VER} ./hack/build-provisioner.sh
 
 hostpath-provisioner-plugin:
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner-csi cmd/plugin/plugin.go
+	GOLANG_VER=${GOLANG_VER} ./hack/build-csi.sh
 
 image: image-controller image-csi
 
@@ -62,7 +63,7 @@ cluster-clean:
 	KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./cluster-sync/clean.sh
 
 test:
-	./hack/run-unit-test.sh
+	GOLANG_VER=${GOLANG_VER} ./hack/run-unit-test.sh
 	hack/language.sh
 
 test-functional:

--- a/hack/build-csi.sh
+++ b/hack/build-csi.sh
@@ -13,21 +13,11 @@
 #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #See the License for the specific language governing permissions and
 #limitations under the License.
-set -e
 
 if [[ -v PROW_JOB_ID ]] ; then
   GOLANG_VER=${GOLANG_VER:-1.16.8}
-  useradd prow -s /bin/bash
-  chown prow:prow -R /home/prow
   eval $(gimme ${GOLANG_VER})
   cp -R ~/.gimme/versions/go${GOLANG_VER}.linux.amd64 /usr/local/go
-  echo "Run go test -v in $PWD"
-  sudo -i -u prow /bin/bash -c 'cd /home/prow/go/src/github.com/kubevirt/hostpath-provisioner && /usr/local/go/bin/go test -v ./cmd/... ./controller/... ./pkg/...'
-  go get -u golang.org/x/lint/golint
-else
-  echo "Run go test -v in $PWD"
-  # Run test
-  go test -v ./cmd/... ./controller/... ./pkg/...
 fi
 
-hack/run-lint-checks.sh
+CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner-csi cmd/plugin/plugin.go

--- a/hack/build-csi.sh
+++ b/hack/build-csi.sh
@@ -14,10 +14,8 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-if [[ -v PROW_JOB_ID ]] ; then
-  GOLANG_VER=${GOLANG_VER:-1.16.8}
-  eval $(gimme ${GOLANG_VER})
-  cp -R ~/.gimme/versions/go${GOLANG_VER}.linux.amd64 /usr/local/go
-fi
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+source "${script_dir}"/common.sh
+setGoInProw $GOLANG_VER
 
 CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner-csi cmd/plugin/plugin.go

--- a/hack/build-provisioner.sh
+++ b/hack/build-provisioner.sh
@@ -13,21 +13,11 @@
 #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #See the License for the specific language governing permissions and
 #limitations under the License.
-set -e
 
 if [[ -v PROW_JOB_ID ]] ; then
   GOLANG_VER=${GOLANG_VER:-1.16.8}
-  useradd prow -s /bin/bash
-  chown prow:prow -R /home/prow
   eval $(gimme ${GOLANG_VER})
   cp -R ~/.gimme/versions/go${GOLANG_VER}.linux.amd64 /usr/local/go
-  echo "Run go test -v in $PWD"
-  sudo -i -u prow /bin/bash -c 'cd /home/prow/go/src/github.com/kubevirt/hostpath-provisioner && /usr/local/go/bin/go test -v ./cmd/... ./controller/... ./pkg/...'
-  go get -u golang.org/x/lint/golint
-else
-  echo "Run go test -v in $PWD"
-  # Run test
-  go test -v ./cmd/... ./controller/... ./pkg/...
 fi
 
-hack/run-lint-checks.sh
+CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 #Copyright 2021 The hostpath provisioner Authors.
 #
 #Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +11,12 @@
 #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #See the License for the specific language governing permissions and
 #limitations under the License.
-script_dir="$(cd "$(dirname "$0")" && pwd -P)"
-source "${script_dir}"/common.sh
-setGoInProw $GOLANG_VER
 
-CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go
+GOLANG_VER=${GOLANG_VER:-1.16.8}
+
+function setGoInProw() {
+  if [[ -v PROW_JOB_ID ]] ; then
+    eval $(gimme ${1})
+    cp -R ~/.gimme/versions/go${1}.linux.amd64 /usr/local/go
+  fi
+}

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+#Copyright 2021 The hostpath provisioner Authors.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
 set -exuo pipefail
 
 function cleanup_gh_install() {

--- a/hack/run-unit-test.sh
+++ b/hack/run-unit-test.sh
@@ -15,12 +15,13 @@
 #limitations under the License.
 set -e
 
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+source "${script_dir}"/common.sh
+setGoInProw $GOLANG_VER
+
 if [[ -v PROW_JOB_ID ]] ; then
-  GOLANG_VER=${GOLANG_VER:-1.16.8}
   useradd prow -s /bin/bash
   chown prow:prow -R /home/prow
-  eval $(gimme ${GOLANG_VER})
-  cp -R ~/.gimme/versions/go${GOLANG_VER}.linux.amd64 /usr/local/go
   echo "Run go test -v in $PWD"
   sudo -i -u prow /bin/bash -c 'cd /home/prow/go/src/github.com/kubevirt/hostpath-provisioner && /usr/local/go/bin/go test -v ./cmd/... ./controller/... ./pkg/...'
   go get -u golang.org/x/lint/golint

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -19,11 +19,12 @@ export KUBEVIRT_NUM_NODES=2
 export KUBEVIRT_PROVIDER=k8s-1.21
 make cluster-down
 make cluster-up
-wget https://dl.google.com/go/go1.16.7.linux-amd64.tar.gz
-tar -xzf go1.16.7.linux-amd64.tar.gz
-export GOROOT=$PWD/go
-export PATH=$GOROOT/bin:$PATH
-echo $PATH
+if [[ -v PROW_JOB_ID ]] ; then
+  GOLANG_VER=${GOLANG_VER:-1.16.8}
+  eval $(gimme ${GOLANG_VER})
+  cp -R ~/.gimme/versions/go${GOLANG_VER}.linux.amd64 /usr/local/go
+fi
+
 go get gotest.tools/gotestsum
 export UPGRADE_FROM=$(curl -s https://github.com/kubevirt/hostpath-provisioner-operator/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
 echo "Upgrading from verions: $UPGRADE_FROM"


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Use the golang container available in PROW system to run
builds and unit tests. Added environment variable so we
can pick which version of go we want to use.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

