### PR TITLE
Update provisioner to take into account both available in operator

### DIFF
--- a/deploy/csi-kubevirt-hostpath-provisioner.yaml
+++ b/deploy/csi-kubevirt-hostpath-provisioner.yaml
@@ -85,6 +85,7 @@ spec:
             - "--v=3"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--version=latest"
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock

--- a/deploy/tests/operator.yaml
+++ b/deploy/tests/operator.yaml
@@ -1879,7 +1879,7 @@ spec:
       containers:
         - name: hostpath-provisioner-operator
           # Replace this with the built image name
-          image: quay.io/kubevirt/hostpath-provisioner-operator:csi
+          image: quay.io/kubevirt/hostpath-provisioner-operator:latest
           command:
           - hostpath-provisioner-operator
           imagePullPolicy: Always

--- a/tests/common.go
+++ b/tests/common.go
@@ -202,9 +202,9 @@ func roundDownCapacityPretty(capacityBytes int64) int64 {
 }
 
 func isCSIStorageClass(k8sClient *kubernetes.Clientset) bool {
-	sc, err := k8sClient.StorageV1().StorageClasses().Get(context.TODO(), "hostpath-provisioner", metav1.GetOptions{})
+	sc, err := k8sClient.StorageV1().StorageClasses().Get(context.TODO(), csiStorageClassName, metav1.GetOptions{})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	gomega.Expect(sc.Name).To(gomega.Equal("hostpath-provisioner"))
+	gomega.Expect(sc.Name).To(gomega.Equal(csiStorageClassName))
 	return sc.Provisioner == csiProvisionerName
 }
 

--- a/tests/sc_test.go
+++ b/tests/sc_test.go
@@ -29,7 +29,19 @@ func TestSCExists(t *testing.T) {
 	tearDown, k8sClient := setupTestCase(t)
 	defer tearDown(t)
 
-	sc, err := k8sClient.StorageV1().StorageClasses().Get(context.TODO(), "hostpath-provisioner", metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	Expect(sc.Name).To(Equal("hostpath-provisioner"))
+	t.Run("legacy provisioner", func(t *testing.T) {
+		sc, err := k8sClient.StorageV1().StorageClasses().Get(context.TODO(), legacyStorageClassName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sc.Name).To(Equal(legacyStorageClassName))
+	})
+	t.Run("legacy provisioner immediate", func(t *testing.T) {
+		sc, err := k8sClient.StorageV1().StorageClasses().Get(context.TODO(), legacyStorageClassNameImmediate, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sc.Name).To(Equal(legacyStorageClassNameImmediate))
+	})
+	t.Run("csi driver", func(t *testing.T) {
+		sc, err := k8sClient.StorageV1().StorageClasses().Get(context.TODO(), csiStorageClassName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sc.Name).To(Equal(csiStorageClassName))
+	})
 }

--- a/vendor/kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_types.go
+++ b/vendor/kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_types.go
@@ -30,9 +30,7 @@ type HostPathProvisionerSpec struct {
 	// PathConfig describes the location and layout of PV storage on nodes
 	PathConfig PathConfig `json:"pathConfig" valid:"required"`
 	// Restrict on which nodes HPP workload pods will be scheduled
-	Workload NodePlacement `json:"workload,omitempty"`
-	// DisableCSI Use old in tree based provisioner instead of CSI provisioner, default: false
-	DisableCsi bool `json:"disableCsi,omitempty"`
+	Workloads NodePlacement `json:"workload,omitempty"`
 }
 
 // HostPathProvisionerStatus defines the observed state of HostPathProvisioner
@@ -58,7 +56,6 @@ type HostPathProvisionerStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=hostpathprovisioners,scope=Cluster
-// +kubebuilder:storageversion
 type HostPathProvisioner struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/vendor/kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1/zz_generated.deepcopy.go
@@ -91,7 +91,7 @@ func (in *HostPathProvisionerList) DeepCopyObject() runtime.Object {
 func (in *HostPathProvisionerSpec) DeepCopyInto(out *HostPathProvisionerSpec) {
 	*out = *in
 	out.PathConfig = in.PathConfig
-	in.Workload.DeepCopyInto(&out.Workload)
+	in.Workloads.DeepCopyInto(&out.Workloads)
 	return
 }
 

--- a/vendor/kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1/zz_generated.openapi.go
+++ b/vendor/kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1/zz_generated.openapi.go
@@ -107,13 +107,6 @@ func schema_pkg_apis_hostpathprovisioner_v1beta1_HostPathProvisionerSpec(ref com
 							Ref:         ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1.NodePlacement"),
 						},
 					},
-					"disableCsi": {
-						SchemaProps: spec.SchemaProps{
-							Description: "DisableCSI Use old in tree based provisioner instead of CSI provisioner, default: false",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 				},
 				Required: []string{"pathConfig"},
 			},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -297,8 +297,6 @@ gopkg.in/inf.v0
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.4.0
 gopkg.in/yaml.v2
-# gotest.tools/gotestsum v1.7.0
-## explicit
 # k8s.io/api v0.22.0 => k8s.io/api v0.21.2
 ## explicit
 k8s.io/api/admissionregistration/v1


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The operator by default deploys both legacy provisioner and csi driver
This modifies the hostpath provisioner code to take that into account
in the deployment examples and functional tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

