### PR TITLE
This fixes an issue when building arm32 images

### DIFF
--- a/cmd/provisioner/hostpath-provisioner.go
+++ b/cmd/provisioner/hostpath-provisioner.go
@@ -225,7 +225,7 @@ func calculatePvCapacity(path string) (*resource.Quantity, error) {
 		return nil, err
 	}
 	// Capacity is total block count * block size
-	quantity := resource.NewQuantity(int64(roundDownCapacityPretty(int64(statfs.Blocks)*statfs.Bsize)), resource.BinarySI)
+	quantity := resource.NewQuantity(int64(roundDownCapacityPretty(int64(statfs.Blocks)*int64(statfs.Bsize))), resource.BinarySI)
 	return quantity, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an ARM32 building issue:

```
cmd/provisioner/hostpath-provisioner.go:228:85: invalid operation:
 int64(statfs.Blocks) * statfs.Bsize (mismatched types int64 and int32)
```

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>

