### PR TITLE
Implement CSI clone

### DIFF
--- a/hack/test-driver.yaml
+++ b/hack/test-driver.yaml
@@ -15,6 +15,7 @@ DriverInfo:
     persistence: true
     singleNodeVolume: true
     snapshotDataSource: false
+    pvcDataSource: true
     topology: true
     capacity: true
   TopologyKeys:

--- a/pkg/hostpath/utils.go
+++ b/pkg/hostpath/utils.go
@@ -227,3 +227,12 @@ func evaluateSharedPathMetric(storagePoolDataDir map[string]string) {
 		poolPathSharedWithOsGauge.Set(0)
 	}
 }
+
+func cloneData(sourcePath, targetPath string) error {
+	out, err := exec.Command("/usr/bin/cp", "-av", "--reflink=auto", sourcePath + "/.", targetPath).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error copying data, %s, %v", string(out), err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Implemented support for CSI clone. The 'clone' is a simple cp command which uses reflink if on an XFS filesystem, other
wise it falls back to a regular copy.

Verify that the source is on the same node as the target otherwise return an error to the caller. This ensures the pod is scheduled on the proper node.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Support for CSI clone on same node.
```

