### PR TITLE
Check if pool paths are shared with OS

### DIFF
--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -40,6 +40,9 @@ func main() {
 	flag.StringVar(&cfg.Version, "version", "", "version of the plugin")
 	flag.Parse()
 
+	klog.V(1).Info("Starting Prometheus metrics endpoint server")
+	hostpath.RunPrometheusServer(":8080")
+
 	klog.V(1).Infof("Starting new HostPathDriver, config: %v", *cfg)
 	driver, err := hostpath.NewHostPathDriver(cfg, dataDir)
 	if err != nil {

--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"kubevirt.io/hostpath-provisioner/pkg/hostpath"
 )
@@ -44,7 +45,8 @@ func main() {
 	hostpath.RunPrometheusServer(":8080")
 
 	klog.V(1).Infof("Starting new HostPathDriver, config: %v", *cfg)
-	driver, err := hostpath.NewHostPathDriver(cfg, dataDir)
+	ctx := signals.SetupSignalHandler()
+	driver, err := hostpath.NewHostPathDriver(ctx, cfg, dataDir)
 	if err != nil {
 		klog.V(1).Infof("Failed to initialize driver: %s", err.Error())
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.15.0
 	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_model v0.2.0
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
 	golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/hack/k8s-e2e.sh
+++ b/hack/k8s-e2e.sh
@@ -50,7 +50,7 @@ then
   ssh_port=$(./cluster-up/cli.sh ports ssh)
   echo "ssh port: ${ssh_port}"
   #Start sshuttle
-  sshuttle -r vagrant@localhost:${ssh_port} 192.168.66.0/24 -e 'ssh -o StrictHostKeyChecking=no -i ./vagrant.key'&
+  sshuttle -r vagrant@127.0.0.1:${ssh_port} 192.168.66.0/24 -e 'ssh -o StrictHostKeyChecking=no -i ./vagrant.key'&
   SSHUTTLE_PID=$!
   function finish() {
     echo "TERMINATING SSHUTTLE!!!!"

--- a/pkg/hostpath/healthcheck.go
+++ b/pkg/hostpath/healthcheck.go
@@ -19,22 +19,21 @@ package hostpath
 import (
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume/util/fs"
 )
 
 type MountPointInfo struct {
-	Target              string           `json:"target"`
-	Source              string           `json:"source"`
-	FsType              string           `json:"fstype"`
-	Options             string           `json:"options"`
+	Target  string `json:"target"`
+	Source  string `json:"source"`
+	FsType  string `json:"fstype"`
+	Options string `json:"options"`
 }
 
 var (
 	checkMountPointExistsFunc = checkMountPointExist
-	getPVStatsFunc = getPVStats
+	getPVStatsFunc            = getPVStats
 )
 
 type FileSystems struct {
@@ -58,23 +57,9 @@ func parseMountInfo(originalMountInfo []byte) ([]MountPointInfo, error) {
 }
 
 func checkMountPointExist(volumePath string) (bool, error) {
-	cmdPath, err := exec.LookPath("findmnt")
-	if err != nil {
-		return false, fmt.Errorf("findmnt not found: %w", err)
-	}
-
-	out, err := exec.Command(cmdPath, volumePath, "--json").CombinedOutput()
+	mountInfos, err := getMountInfos(volumePath)
 	if err != nil {
 		return false, err
-	}
-
-	if len(out) < 1 {
-		return false, fmt.Errorf("mount point info is nil")
-	}
-
-	mountInfos, err := parseMountInfo([]byte(out))
-	if err != nil {
-		return false, fmt.Errorf("failed to parse the mount infos: %+v", err)
 	}
 
 	for _, mountInfo := range mountInfos {
@@ -96,7 +81,7 @@ func checkPVUsage(volumePath string) (int64, int64, error) {
 		return fsavailable, inodesFree, err
 	}
 
-	klog.V(3).Infof("fs available: %+v, total capacity: %d, percentage available: %.2f, number of free inodes: %d", fsavailable, capacity, float64(fsavailable) / float64(capacity) * 100, inodesFree)
+	klog.V(3).Infof("fs available: %+v, total capacity: %d, percentage available: %.2f, number of free inodes: %d", fsavailable, capacity, float64(fsavailable)/float64(capacity)*100, inodesFree)
 	return fsavailable, inodesFree, nil
 }
 

--- a/pkg/hostpath/hostpath_test.go
+++ b/pkg/hostpath/hostpath_test.go
@@ -23,6 +23,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
 
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/mount"
@@ -36,17 +39,22 @@ func Test_NewHostPathDriver(t *testing.T) {
 	RegisterTestingT(t)
 	tempDir, err := ioutil.TempDir(os.TempDir(), "")
 	Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(tempDir)
+	oldCsiSocketDir := csiSocketDir
+	csiSocketDir = "/dev"
+	defer func() {
+		os.RemoveAll(tempDir)
+		csiSocketDir = oldCsiSocketDir
+	}()
 
 	t.Run("blank config", func(t *testing.T) {
-		cfg := &Config {}
+		cfg := &Config{}
 		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no driver name provided")))
 	})
 
 	t.Run("just driver name", func(t *testing.T) {
-		cfg := &Config {
+		cfg := &Config{
 			DriverName: "test_driver",
 		}
 		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
@@ -55,31 +63,33 @@ func Test_NewHostPathDriver(t *testing.T) {
 	})
 
 	t.Run("no driver endpoint", func(t *testing.T) {
-		cfg := &Config {
+		cfg := &Config{
 			DriverName: "test_driver",
-			NodeID: "test_nodeid",
+			NodeID:     "test_nodeid",
 		}
 		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no driver endpoint provided")))
 	})
+
 	t.Run("no version", func(t *testing.T) {
-		cfg := &Config {
+		cfg := &Config{
 			DriverName: "test_driver",
-			NodeID: "test_nodeid",
-			Endpoint: "unix://test.sock",
+			NodeID:     "test_nodeid",
+			Endpoint:   "unix://test.sock",
 		}
 		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no version provided")))
 	})
+
 	t.Run("valid config", func(t *testing.T) {
-		cfg := &Config {
+		cfg := &Config{
 			DriverName: "test_driver",
-			NodeID: "test_nodeid",
-			Endpoint: "unix://test.sock",
-			Version: "test_version",
-			Mounter: mount.NewFakeMounter([]mount.MountPoint{}), // If not set it will try to create a real mounter
+			NodeID:     "test_nodeid",
+			Endpoint:   "unix://test.sock",
+			Version:    "test_version",
+			Mounter:    mount.NewFakeMounter([]mount.MountPoint{}), // If not set it will try to create a real mounter
 		}
 		drv, err := NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
 		Expect(err).ToNot(HaveOccurred())
@@ -88,5 +98,40 @@ func Test_NewHostPathDriver(t *testing.T) {
 		Expect(drv.identity).ToNot(BeNil())
 		_, err = os.Stat(filepath.Join(tempDir, "testdatadir"))
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("valid config pool path shared with OS metric", func(t *testing.T) {
+		cfg := &Config{
+			DriverName: "test_driver",
+			NodeID:     "test_nodeid",
+			Endpoint:   "unix://test.sock",
+			Version:    "test_version",
+			Mounter:    mount.NewFakeMounter([]mount.MountPoint{}), // If not set it will try to create a real mounter
+		}
+		drv, err := NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(drv.node).ToNot(BeNil())
+		Expect(drv.controller).ToNot(BeNil())
+		Expect(drv.identity).ToNot(BeNil())
+		_, err = os.Stat(filepath.Join(tempDir, "testdatadir"))
+		Expect(err).ToNot(HaveOccurred())
+		time.Sleep(1 * time.Second)
+		dto := &io_prometheus_client.Metric{}
+		poolPathSharedWithOsGauge.Write(dto)
+		Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(0))
+
+		// Now switch the socket dir, so we are indeed sharing path with OS (we call NewHostPathDriver with tmpfs backed folder)
+		csiSocketDir = "/tmp"
+		drv, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(drv.node).ToNot(BeNil())
+		Expect(drv.controller).ToNot(BeNil())
+		Expect(drv.identity).ToNot(BeNil())
+		_, err = os.Stat(filepath.Join(tempDir, "testdatadir"))
+		Expect(err).ToNot(HaveOccurred())
+		time.Sleep(1 * time.Second)
+		dto = &io_prometheus_client.Metric{}
+		poolPathSharedWithOsGauge.Write(dto)
+		Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(1))
 	})
 }

--- a/pkg/hostpath/hostpath_test.go
+++ b/pkg/hostpath/hostpath_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hostpath
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -48,7 +49,7 @@ func Test_NewHostPathDriver(t *testing.T) {
 
 	t.Run("blank config", func(t *testing.T) {
 		cfg := &Config{}
-		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
+		_, err = NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no driver name provided")))
 	})
@@ -57,7 +58,7 @@ func Test_NewHostPathDriver(t *testing.T) {
 		cfg := &Config{
 			DriverName: "test_driver",
 		}
-		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
+		_, err = NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no node id provided")))
 	})
@@ -67,7 +68,7 @@ func Test_NewHostPathDriver(t *testing.T) {
 			DriverName: "test_driver",
 			NodeID:     "test_nodeid",
 		}
-		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
+		_, err = NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no driver endpoint provided")))
 	})
@@ -78,7 +79,7 @@ func Test_NewHostPathDriver(t *testing.T) {
 			NodeID:     "test_nodeid",
 			Endpoint:   "unix://test.sock",
 		}
-		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
+		_, err = NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no version provided")))
 	})
@@ -91,7 +92,7 @@ func Test_NewHostPathDriver(t *testing.T) {
 			Version:    "test_version",
 			Mounter:    mount.NewFakeMounter([]mount.MountPoint{}), // If not set it will try to create a real mounter
 		}
-		drv, err := NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
+		drv, err := NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(drv.node).ToNot(BeNil())
 		Expect(drv.controller).ToNot(BeNil())
@@ -108,7 +109,7 @@ func Test_NewHostPathDriver(t *testing.T) {
 			Version:    "test_version",
 			Mounter:    mount.NewFakeMounter([]mount.MountPoint{}), // If not set it will try to create a real mounter
 		}
-		drv, err := NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
+		drv, err := NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(drv.node).ToNot(BeNil())
 		Expect(drv.controller).ToNot(BeNil())
@@ -122,7 +123,7 @@ func Test_NewHostPathDriver(t *testing.T) {
 
 		// Now switch the socket dir, so we are indeed sharing path with OS (we call NewHostPathDriver with tmpfs backed folder)
 		csiSocketDir = "/tmp"
-		drv, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
+		drv, err = NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(drv.node).ToNot(BeNil())
 		Expect(drv.controller).ToNot(BeNil())

--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	TopologyKeyNode = "topology.hostpath.csi/node"
+	TopologyKeyNode     = "topology.hostpath.csi/node"
 	ephemeralContextKey = "csi.storage.k8s.io/ephemeral"
 )
 
@@ -39,7 +39,7 @@ type hostPathNode struct {
 }
 
 func NewHostPathNode(config *Config) *hostPathNode {
-	return &hostPathNode {
+	return &hostPathNode{
 		cfg: config,
 	}
 }
@@ -86,14 +86,14 @@ func (hpn *hostPathNode) NodePublishVolume(ctx context.Context, req *csi.NodePub
 	}
 
 	targetPath := req.GetTargetPath()
-	
+
 	if canMnt, err := hpn.canMountVolume(targetPath); err != nil {
 		return nil, err
 	} else if !canMnt {
 		klog.V(3).Infof("Cannot mount to target path: %s", targetPath)
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
-	
+
 	if err := hpn.mountVolume(targetPath, req); err != nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func (hpn *hostPathNode) NodeUnstageVolume(ctx context.Context, req *csi.NodeUns
 
 func (hpn *hostPathNode) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	resp := &csi.NodeGetInfoResponse{
-		NodeId:            hpn.cfg.NodeID,
+		NodeId: hpn.cfg.NodeID,
 	}
 
 	resp.AccessibleTopology = &csi.Topology{
@@ -296,7 +296,6 @@ func (hpn *hostPathNode) NodeGetCapabilities(ctx context.Context, req *csi.NodeG
 
 	return &csi.NodeGetCapabilitiesResponse{Capabilities: caps}, nil
 }
-
 
 func (hpn *hostPathNode) validateNodeGetVolumeStatsRequest(req *csi.NodeGetVolumeStatsRequest) error {
 	if len(req.GetVolumeId()) == 0 {

--- a/pkg/hostpath/utils.go
+++ b/pkg/hostpath/utils.go
@@ -200,14 +200,15 @@ func checkVolumePathSharedWithOS(volumePath string) bool {
 		return false
 	}
 
-	pathSource := mountInfosForPath[0].Source
-	csiSocketSource := mountInfosForCsiSocketDir[0].Source
-	if strings.Contains(pathSource, "[") {
-		pathSource = strings.Split(pathSource, "[")[0]
-	}
-	if strings.Contains(csiSocketSource, "[") {
-		csiSocketSource = strings.Split(csiSocketSource, "[")[0]
-	}
+	pathSource := extractDeviceFromMountInfoSource(mountInfosForPath[0].Source)
+	csiSocketSource := extractDeviceFromMountInfoSource(mountInfosForCsiSocketDir[0].Source)
 
 	return pathSource == csiSocketSource
+}
+
+func extractDeviceFromMountInfoSource(source string) string {
+	if strings.Contains(source, "[") {
+		return strings.Split(source, "[")[0]
+	}
+	return source
 }

--- a/pkg/hostpath/utils.go
+++ b/pkg/hostpath/utils.go
@@ -212,3 +212,18 @@ func extractDeviceFromMountInfoSource(source string) string {
 	}
 	return source
 }
+
+func evaluateSharedPathMetric(storagePoolDataDir map[string]string) {
+	pathShared := false
+	for k, v := range storagePoolDataDir {
+		if checkVolumePathSharedWithOS(v) {
+			pathShared = true
+			klog.V(1).Infof("pool (%s, %s), shares path with OS which can lead to node disk pressure", k, v)
+		}
+	}
+	if pathShared {
+		poolPathSharedWithOsGauge.Set(1)
+	} else {
+		poolPathSharedWithOsGauge.Set(0)
+	}
+}

--- a/pkg/hostpath/utils_test.go
+++ b/pkg/hostpath/utils_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	validVolId = "valid"
+	validVolId   = "valid"
 	invalidVolId = "invalid"
 )
 
@@ -36,37 +36,37 @@ func Test_roundDownCapacityPretty(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    args
-		want    int64
+		name string
+		args args
+		want int64
 	}{
 		{
 			name: "Rounds Gigs properly",
 			args: args{
 				size: int64(2 * gib),
 			},
-			want:    int64(2 * gib),
+			want: int64(2 * gib),
 		},
 		{
 			name: "Rounds Gigs properly with minor add",
 			args: args{
 				size: int64((2 * gib) + 2),
 			},
-			want:    int64(2 * gib),
+			want: int64(2 * gib),
 		},
 		{
 			name: "Not large enough for GiB, rounded down to smaller MiB",
 			args: args{
 				size: int64((2 * gib) - 2),
 			},
-			want:    int64(2047 * mib),
+			want: int64(2047 * mib),
 		},
 		{
 			name: "Large GiB, rounded down to one smaller GiB",
 			args: args{
 				size: int64((20 * gib) - 2),
 			},
-			want:    int64(19 * gib),
+			want: int64(19 * gib),
 		},
 	}
 	for _, tt := range tests {
@@ -85,22 +85,22 @@ func Test_UtilCreateVolume(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 	tests := []struct {
-		name string
-		base string
+		name  string
+		base  string
 		volId string
-		want bool
-	} {
+		want  bool
+	}{
 		{
-			name: "validVolId",
-			base: tempDir,
+			name:  "validVolId",
+			base:  tempDir,
 			volId: validVolId,
-			want: false,
+			want:  false,
 		},
 		{
-			name: "invalidVolId",
-			base: "/notvalid",
+			name:  "invalidVolId",
+			base:  "/notvalid",
 			volId: invalidVolId,
-			want: true,
+			want:  true,
 		},
 	}
 	for _, tt := range tests {
@@ -130,4 +130,38 @@ func Test_DeleteVolume(t *testing.T) {
 		err = DeleteVolume("/dev", "null")
 		Expect(err).To(HaveOccurred())
 	})
+}
+
+func Test_extractDeviceFromMountInfoSource(t *testing.T) {
+	RegisterTestingT(t)
+	type args struct {
+		source string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "With square brackets should return just device",
+			args: args{
+				source: "/dev/vda4[/ostree/deploy/rhcos/var/lib/kubelet/plugins/csi-hostpath]",
+			},
+			want: "/dev/vda4",
+		},
+		{
+			name: "Without square brackets should return exactly that",
+			args: args{
+				source: "/dev/vda4",
+			},
+			want: "/dev/vda4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractDeviceFromMountInfoSource(tt.args.source)
+			Expect(got).To(Equal(tt.want))
+		})
+	}
 }

--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package sanity
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -29,7 +30,7 @@ import (
 )
 
 const (
-	sanityEndpoint = "sanity.sock"
+	sanityEndpoint   = "sanity.sock"
 	TestDatadirValue = "[{\"name\":\"legacy\",\"path\":\"%s\"}]"
 )
 
@@ -52,13 +53,13 @@ func TestMyDriver(t *testing.T) {
 	cfg.Version = "test-version"
 	cfg.NodeID = "testnode"
 
-	driver, err := hostpath.NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, volumeDir))
+	driver, err := hostpath.NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, volumeDir))
 	Expect(err).ToNot(HaveOccurred())
 
-	go func() { 		
+	go func() {
 		err := driver.Run()
 		Expect(err).ToNot(HaveOccurred())
-	}() 
+	}()
 
 	testConfig := sanity.NewTestConfig()
 	// Set configuration options as needed
@@ -68,4 +69,3 @@ func TestMyDriver(t *testing.T) {
 	// Now call the test suite
 	sanity.Test(t, testConfig)
 }
-

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -139,6 +139,7 @@ github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.2.0
+## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.26.0
 github.com/prometheus/common/expfmt


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following up https://github.com/kubevirt/hostpath-provisioner-operator/pull/207, we will update the metric that tells us if any pool path is shared with OS so that we can alert about it. 
Sharing paths with the OS can lead to node pressure and harm node operation.

A healthy setup will look like so (note source section):
```bash
[root@hostpath-provisioner-csi-ctxww /]# findmnt -T /csi
TARGET SOURCE                                                               FSTYPE OPTIONS
/csi   /dev/vda4[/ostree/deploy/rhcos/var/lib/kubelet/plugins/csi-hostpath] xfs    rw,relatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,prjquota
[root@hostpath-provisioner-csi-ctxww /]# findmnt -T /local-data-dir/csi
TARGET              SOURCE    FSTYPE OPTIONS
/local-data-dir/csi /dev/rbd0 ext4   rw,relatime,seclabel,stripe=16
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2038985

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: No feedback when HPP path is sharing host filesystem
```

