### PR TITLE
[release-v0.12] Manual backport of #95, #100 for CI to pass

### DIFF
--- a/cluster-sync/clean.sh
+++ b/cluster-sync/clean.sh
@@ -25,5 +25,5 @@ fi
 
 _kubectl delete -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/master/deploy/operator.yaml -n hostpath-provisioner --ignore-not-found
 _kubectl delete -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/master/deploy/namespace.yaml --ignore-not-found
-_kubectl delete -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/master/deploy/storageclass-wffc.yaml --ignore-not-found
+_kubectl delete -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/master/deploy/storageclass-wffc-legacy.yaml --ignore-not-found
 _kubectl delete -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/master/deploy/storageclass-immediate.yaml --ignore-not-found

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -86,7 +86,7 @@ _kubectl patch deployment hostpath-provisioner-operator -n hostpath-provisioner 
 
 _kubectl rollout status -n hostpath-provisioner deployment/hostpath-provisioner-operator --timeout=120s
 _kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/hostpathprovisioner_legacy_cr.yaml
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/storageclass-wffc.yaml
+_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/storageclass-wffc-legacy.yaml
 _kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/storageclass-wffc-legacy-csi.yaml
 
 cat <<EOF | _kubectl apply -f -

--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"kubevirt.io/hostpath-provisioner/pkg/hostpath"
 )
@@ -40,8 +41,12 @@ func main() {
 	flag.StringVar(&cfg.Version, "version", "", "version of the plugin")
 	flag.Parse()
 
+	klog.V(1).Info("Starting Prometheus metrics endpoint server")
+	hostpath.RunPrometheusServer(":8080")
+
 	klog.V(1).Infof("Starting new HostPathDriver, config: %v", *cfg)
-	driver, err := hostpath.NewHostPathDriver(cfg, dataDir)
+	ctx := signals.SetupSignalHandler()
+	driver, err := hostpath.NewHostPathDriver(ctx, cfg, dataDir)
 	if err != nil {
 		klog.V(1).Infof("Failed to initialize driver: %s", err.Error())
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.15.0
 	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_model v0.2.0
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
 	golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/hack/k8s-e2e.sh
+++ b/hack/k8s-e2e.sh
@@ -50,7 +50,7 @@ then
   ssh_port=$(./cluster-up/cli.sh ports ssh)
   echo "ssh port: ${ssh_port}"
   #Start sshuttle
-  sshuttle -r vagrant@localhost:${ssh_port} 192.168.66.0/24 -e 'ssh -o StrictHostKeyChecking=no -i ./vagrant.key'&
+  sshuttle -r vagrant@127.0.0.1:${ssh_port} 192.168.66.0/24 -e 'ssh -o StrictHostKeyChecking=no -i ./vagrant.key'&
   SSHUTTLE_PID=$!
   function finish() {
     echo "TERMINATING SSHUTTLE!!!!"

--- a/ose-tests/csi_cert_os.yaml
+++ b/ose-tests/csi_cert_os.yaml
@@ -1,0 +1,78 @@
+ShortName: hpp
+StorageClass:
+  # Load a StorageClass from the given file. This file must be in the same directory as this one
+  FromFile: storageclass.yaml
+
+SnapshotClass:
+  # Must be set to enable snapshotting tests
+  FromName: true
+
+DriverInfo:
+  # Internal name of the driver, this is used as a display name in the test case and test objects
+  Name: kubevirt.io.hostpath-provisioner 
+
+  # The range of disk size supported by this driver
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 16Ti
+
+  # Map of strings for supported FS types
+  SupportedFsType:
+    xfs: {}
+
+  # Map of strings for supported mount options
+  SupportedMountOption:
+
+  # Optional list of topology keys that the driver supports
+  TopologyKeys: ["topology.hostpath.csi/node"]
+
+  # Optional number of allowed topologies that the driver requires. Only relevenat if TopologyKeys is set
+  NumAllowedTopologies: 1
+
+  # Map of strings for required mount options
+  # RequiredMountOption:
+
+  # Optional list of access modes required for provisiong. Default is RWO
+  # RequiredAccessModes:
+
+  # Map that represents the capabilities the driver supports
+  Capabilities:
+    # Data is persistest accross pod restarts
+    persistence: true
+
+    # Volume ownership via fsGroup
+    fsGroup: true
+
+    # Raw block mode
+    block: false
+
+    # Exec a file in the volume
+    exec: true
+
+    # Support for volume limits
+    volumeLimits: false
+
+    # Support for volume expansion in controllers
+    controllerExpansion: false
+
+    # Support for volume expansion in nodes
+    nodeExpansion: false
+
+    # Support volume that an run on single node only (like hostpath)
+    singleNodeVolume: false
+
+    # Support ReadWriteMany access modes
+    RWX: false
+
+    # Support topology
+    topology: true
+
+    # Support populate data from snapshot
+    snapshotDataSource: false
+
+    # Support populated data from PVC
+    pvcDataSource: false
+
+InlineVolumes:
+- shared: true
+

--- a/ose-tests/run_ose_tests.md
+++ b/ose-tests/run_ose_tests.md
@@ -1,0 +1,17 @@
+# Running Open Shift CSI certification tests
+
+### Prerequisites
+
+Have a running Open Shift cluster. And store a kubeconfig file in this directory named `kubeconfig.yaml` This will be passed as the KUBECONFIG parameter in the command below. The `storageclass.yaml` and `csi_cert_os.yaml` are needed to configure which tests to run and what storage class to use.
+
+Pull the ose-tests container from the Red Hat registry.
+
+### Command
+Run the below command to execute the tests against your Open Shift cluster.
+
+```bash
+podman run -v `pwd`:/data:z --rm -it registry.redhat.io/openshift4/ose-tests sh -c "KUBECONFIG=/data/kubeconfig.yaml TEST_CSI_DRIVER_FILES=/data/csi_cert_os.yaml /usr/bin/openshift-tests run openshift/csi --junit-dir /data/results"
+```
+
+The results will be stored in the results directory.
+

--- a/ose-tests/storageclass.yaml
+++ b/ose-tests/storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hostpath-csi
+provisioner: kubevirt.io.hostpath-provisioner
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  storagePool: local

--- a/pkg/hostpath/healthcheck.go
+++ b/pkg/hostpath/healthcheck.go
@@ -19,22 +19,21 @@ package hostpath
 import (
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume/util/fs"
 )
 
 type MountPointInfo struct {
-	Target              string           `json:"target"`
-	Source              string           `json:"source"`
-	FsType              string           `json:"fstype"`
-	Options             string           `json:"options"`
+	Target  string `json:"target"`
+	Source  string `json:"source"`
+	FsType  string `json:"fstype"`
+	Options string `json:"options"`
 }
 
 var (
 	checkMountPointExistsFunc = checkMountPointExist
-	getPVStatsFunc = getPVStats
+	getPVStatsFunc            = getPVStats
 )
 
 type FileSystems struct {
@@ -58,23 +57,9 @@ func parseMountInfo(originalMountInfo []byte) ([]MountPointInfo, error) {
 }
 
 func checkMountPointExist(volumePath string) (bool, error) {
-	cmdPath, err := exec.LookPath("findmnt")
-	if err != nil {
-		return false, fmt.Errorf("findmnt not found: %w", err)
-	}
-
-	out, err := exec.Command(cmdPath, volumePath, "--json").CombinedOutput()
+	mountInfos, err := getMountInfos(volumePath)
 	if err != nil {
 		return false, err
-	}
-
-	if len(out) < 1 {
-		return false, fmt.Errorf("mount point info is nil")
-	}
-
-	mountInfos, err := parseMountInfo([]byte(out))
-	if err != nil {
-		return false, fmt.Errorf("failed to parse the mount infos: %+v", err)
 	}
 
 	for _, mountInfo := range mountInfos {
@@ -96,7 +81,7 @@ func checkPVUsage(volumePath string) (int64, int64, error) {
 		return fsavailable, inodesFree, err
 	}
 
-	klog.V(3).Infof("fs available: %+v, total capacity: %d, percentage available: %.2f, number of free inodes: %d", fsavailable, capacity, float64(fsavailable) / float64(capacity) * 100, inodesFree)
+	klog.V(3).Infof("fs available: %+v, total capacity: %d, percentage available: %.2f, number of free inodes: %d", fsavailable, capacity, float64(fsavailable)/float64(capacity)*100, inodesFree)
 	return fsavailable, inodesFree, nil
 }
 

--- a/pkg/hostpath/hostpath_test.go
+++ b/pkg/hostpath/hostpath_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package hostpath
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
 
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/mount"
@@ -36,57 +40,99 @@ func Test_NewHostPathDriver(t *testing.T) {
 	RegisterTestingT(t)
 	tempDir, err := ioutil.TempDir(os.TempDir(), "")
 	Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(tempDir)
+	oldCsiSocketDir := csiSocketDir
+	csiSocketDir = "/dev"
+	defer func() {
+		os.RemoveAll(tempDir)
+		csiSocketDir = oldCsiSocketDir
+	}()
 
 	t.Run("blank config", func(t *testing.T) {
-		cfg := &Config {}
-		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
+		cfg := &Config{}
+		_, err = NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no driver name provided")))
 	})
 
 	t.Run("just driver name", func(t *testing.T) {
-		cfg := &Config {
+		cfg := &Config{
 			DriverName: "test_driver",
 		}
-		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
+		_, err = NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no node id provided")))
 	})
 
 	t.Run("no driver endpoint", func(t *testing.T) {
-		cfg := &Config {
+		cfg := &Config{
 			DriverName: "test_driver",
-			NodeID: "test_nodeid",
+			NodeID:     "test_nodeid",
 		}
-		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
+		_, err = NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no driver endpoint provided")))
 	})
+
 	t.Run("no version", func(t *testing.T) {
-		cfg := &Config {
+		cfg := &Config{
 			DriverName: "test_driver",
-			NodeID: "test_nodeid",
-			Endpoint: "unix://test.sock",
+			NodeID:     "test_nodeid",
+			Endpoint:   "unix://test.sock",
 		}
-		_, err = NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, tempDir))
+		_, err = NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, tempDir))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeEquivalentTo(errors.New("no version provided")))
 	})
+
 	t.Run("valid config", func(t *testing.T) {
-		cfg := &Config {
+		cfg := &Config{
 			DriverName: "test_driver",
-			NodeID: "test_nodeid",
-			Endpoint: "unix://test.sock",
-			Version: "test_version",
-			Mounter: mount.NewFakeMounter([]mount.MountPoint{}), // If not set it will try to create a real mounter
+			NodeID:     "test_nodeid",
+			Endpoint:   "unix://test.sock",
+			Version:    "test_version",
+			Mounter:    mount.NewFakeMounter([]mount.MountPoint{}), // If not set it will try to create a real mounter
 		}
-		drv, err := NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
+		drv, err := NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(drv.node).ToNot(BeNil())
 		Expect(drv.controller).ToNot(BeNil())
 		Expect(drv.identity).ToNot(BeNil())
 		_, err = os.Stat(filepath.Join(tempDir, "testdatadir"))
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("valid config pool path shared with OS metric", func(t *testing.T) {
+		cfg := &Config{
+			DriverName: "test_driver",
+			NodeID:     "test_nodeid",
+			Endpoint:   "unix://test.sock",
+			Version:    "test_version",
+			Mounter:    mount.NewFakeMounter([]mount.MountPoint{}), // If not set it will try to create a real mounter
+		}
+		drv, err := NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(drv.node).ToNot(BeNil())
+		Expect(drv.controller).ToNot(BeNil())
+		Expect(drv.identity).ToNot(BeNil())
+		_, err = os.Stat(filepath.Join(tempDir, "testdatadir"))
+		Expect(err).ToNot(HaveOccurred())
+		time.Sleep(1 * time.Second)
+		dto := &io_prometheus_client.Metric{}
+		poolPathSharedWithOsGauge.Write(dto)
+		Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(0))
+
+		// Now switch the socket dir, so we are indeed sharing path with OS (we call NewHostPathDriver with tmpfs backed folder)
+		csiSocketDir = "/tmp"
+		drv, err = NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, filepath.Join(tempDir, "testdatadir")))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(drv.node).ToNot(BeNil())
+		Expect(drv.controller).ToNot(BeNil())
+		Expect(drv.identity).ToNot(BeNil())
+		_, err = os.Stat(filepath.Join(tempDir, "testdatadir"))
+		Expect(err).ToNot(HaveOccurred())
+		time.Sleep(1 * time.Second)
+		dto = &io_prometheus_client.Metric{}
+		poolPathSharedWithOsGauge.Write(dto)
+		Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(1))
 	})
 }

--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	TopologyKeyNode = "topology.hostpath.csi/node"
+	TopologyKeyNode     = "topology.hostpath.csi/node"
 	ephemeralContextKey = "csi.storage.k8s.io/ephemeral"
 )
 
@@ -39,7 +39,7 @@ type hostPathNode struct {
 }
 
 func NewHostPathNode(config *Config) *hostPathNode {
-	return &hostPathNode {
+	return &hostPathNode{
 		cfg: config,
 	}
 }
@@ -86,14 +86,14 @@ func (hpn *hostPathNode) NodePublishVolume(ctx context.Context, req *csi.NodePub
 	}
 
 	targetPath := req.GetTargetPath()
-	
+
 	if canMnt, err := hpn.canMountVolume(targetPath); err != nil {
 		return nil, err
 	} else if !canMnt {
 		klog.V(3).Infof("Cannot mount to target path: %s", targetPath)
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
-	
+
 	if err := hpn.mountVolume(targetPath, req); err != nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func (hpn *hostPathNode) NodeUnstageVolume(ctx context.Context, req *csi.NodeUns
 
 func (hpn *hostPathNode) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	resp := &csi.NodeGetInfoResponse{
-		NodeId:            hpn.cfg.NodeID,
+		NodeId: hpn.cfg.NodeID,
 	}
 
 	resp.AccessibleTopology = &csi.Topology{
@@ -296,7 +296,6 @@ func (hpn *hostPathNode) NodeGetCapabilities(ctx context.Context, req *csi.NodeG
 
 	return &csi.NodeGetCapabilitiesResponse{Capabilities: caps}, nil
 }
-
 
 func (hpn *hostPathNode) validateNodeGetVolumeStatsRequest(req *csi.NodeGetVolumeStatsRequest) error {
 	if len(req.GetVolumeId()) == 0 {

--- a/pkg/hostpath/utils_test.go
+++ b/pkg/hostpath/utils_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	validVolId = "valid"
+	validVolId   = "valid"
 	invalidVolId = "invalid"
 )
 
@@ -36,37 +36,37 @@ func Test_roundDownCapacityPretty(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    args
-		want    int64
+		name string
+		args args
+		want int64
 	}{
 		{
 			name: "Rounds Gigs properly",
 			args: args{
 				size: int64(2 * gib),
 			},
-			want:    int64(2 * gib),
+			want: int64(2 * gib),
 		},
 		{
 			name: "Rounds Gigs properly with minor add",
 			args: args{
 				size: int64((2 * gib) + 2),
 			},
-			want:    int64(2 * gib),
+			want: int64(2 * gib),
 		},
 		{
 			name: "Not large enough for GiB, rounded down to smaller MiB",
 			args: args{
 				size: int64((2 * gib) - 2),
 			},
-			want:    int64(2047 * mib),
+			want: int64(2047 * mib),
 		},
 		{
 			name: "Large GiB, rounded down to one smaller GiB",
 			args: args{
 				size: int64((20 * gib) - 2),
 			},
-			want:    int64(19 * gib),
+			want: int64(19 * gib),
 		},
 	}
 	for _, tt := range tests {
@@ -85,22 +85,22 @@ func Test_UtilCreateVolume(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 	tests := []struct {
-		name string
-		base string
+		name  string
+		base  string
 		volId string
-		want bool
-	} {
+		want  bool
+	}{
 		{
-			name: "validVolId",
-			base: tempDir,
+			name:  "validVolId",
+			base:  tempDir,
 			volId: validVolId,
-			want: false,
+			want:  false,
 		},
 		{
-			name: "invalidVolId",
-			base: "/notvalid",
+			name:  "invalidVolId",
+			base:  "/notvalid",
 			volId: invalidVolId,
-			want: true,
+			want:  true,
 		},
 	}
 	for _, tt := range tests {
@@ -130,4 +130,38 @@ func Test_DeleteVolume(t *testing.T) {
 		err = DeleteVolume("/dev", "null")
 		Expect(err).To(HaveOccurred())
 	})
+}
+
+func Test_extractDeviceFromMountInfoSource(t *testing.T) {
+	RegisterTestingT(t)
+	type args struct {
+		source string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "With square brackets should return just device",
+			args: args{
+				source: "/dev/vda4[/ostree/deploy/rhcos/var/lib/kubelet/plugins/csi-hostpath]",
+			},
+			want: "/dev/vda4",
+		},
+		{
+			name: "Without square brackets should return exactly that",
+			args: args{
+				source: "/dev/vda4",
+			},
+			want: "/dev/vda4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractDeviceFromMountInfoSource(tt.args.source)
+			Expect(got).To(Equal(tt.want))
+		})
+	}
 }

--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package sanity
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -29,7 +30,7 @@ import (
 )
 
 const (
-	sanityEndpoint = "sanity.sock"
+	sanityEndpoint   = "sanity.sock"
 	TestDatadirValue = "[{\"name\":\"legacy\",\"path\":\"%s\"}]"
 )
 
@@ -52,13 +53,13 @@ func TestMyDriver(t *testing.T) {
 	cfg.Version = "test-version"
 	cfg.NodeID = "testnode"
 
-	driver, err := hostpath.NewHostPathDriver(cfg, fmt.Sprintf(TestDatadirValue, volumeDir))
+	driver, err := hostpath.NewHostPathDriver(context.TODO(), cfg, fmt.Sprintf(TestDatadirValue, volumeDir))
 	Expect(err).ToNot(HaveOccurred())
 
-	go func() { 		
+	go func() {
 		err := driver.Run()
 		Expect(err).ToNot(HaveOccurred())
-	}() 
+	}()
 
 	testConfig := sanity.NewTestConfig()
 	// Set configuration options as needed
@@ -68,4 +69,3 @@ func TestMyDriver(t *testing.T) {
 	// Now call the test suite
 	sanity.Test(t, testConfig)
 }
-

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -139,6 +139,7 @@ github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.2.0
+## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.26.0
 github.com/prometheus/common/expfmt


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
CI in `release-v0.12` needs both #95 (yaml filename change) & #100 (`localhost->127.0.0.1` for shuttle and prometheus curl calls) to pass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: No feedback when HPP path is sharing host filesystem
```

