### PR TITLE
Add ceph PVC backing storage pool CI lane

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -85,9 +85,15 @@ _kubectl get pods -n hostpath-provisioner
 _kubectl patch deployment hostpath-provisioner-operator -n hostpath-provisioner --patch-file cluster-sync/patch.yaml
 
 _kubectl rollout status -n hostpath-provisioner deployment/hostpath-provisioner-operator --timeout=120s
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/hostpathprovisioner_legacy_cr.yaml
+HPP_CR_PATH="https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/hostpathprovisioner_legacy_cr.yaml"
+HPP_CSI_SC="https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/storageclass-wffc-legacy-csi.yaml"
+if [ "${KUBEVIRT_STORAGE}" == "rook-ceph-default" ] && [ "${HPP_CR_TYPE}" == "storagepool-pvc-template" ]; then
+  HPP_CR_PATH="deploy/tests/hostpathprovisioner_ceph_pvc_pool_cr.yaml"
+  HPP_CSI_SC="deploy/tests/storageclass_wffc_ceph_pool.yaml"
+fi
+_kubectl apply -f $HPP_CR_PATH
 _kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/storageclass-wffc-legacy.yaml
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/storageclass-wffc-legacy-csi.yaml
+_kubectl apply -f $HPP_CSI_SC
 
 cat <<EOF | _kubectl apply -f -
 apiVersion: storage.k8s.io/v1

--- a/deploy/tests/hostpathprovisioner_ceph_pvc_pool_cr.yaml
+++ b/deploy/tests/hostpathprovisioner_ceph_pvc_pool_cr.yaml
@@ -1,0 +1,20 @@
+apiVersion: hostpathprovisioner.kubevirt.io/v1beta1
+kind: HostPathProvisioner
+metadata:
+  name: hostpath-provisioner
+spec:
+  imagePullPolicy: Always
+  storagePools:
+      - name: ceph
+        pvcTemplate:
+          volumeMode: Block
+          storageClassName: rook-ceph-block
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 5Gi
+        path: "/var/hpvolumes"
+  workload:
+    nodeSelector:
+      kubernetes.io/os: linux

--- a/deploy/tests/storageclass_wffc_ceph_pool.yaml
+++ b/deploy/tests/storageclass_wffc_ceph_pool.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hostpath-csi
+provisioner: kubevirt.io.hostpath-provisioner
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  storagePool: ceph

--- a/tests/common.go
+++ b/tests/common.go
@@ -45,7 +45,7 @@ const (
 	GiB int64 = 1024 * MiB
 	TiB int64 = 1024 * GiB
 
-	csiProvisionerName = "kubevirt.io.hostpath-provisioner"
+	csiProvisionerName    = "kubevirt.io.hostpath-provisioner"
 	legacyProvisionerName = "kubevirt.io/hostpath-provisioner"
 )
 
@@ -248,3 +248,11 @@ func isCSIStorageClass(k8sClient *kubernetes.Clientset) bool {
 	return sc.Provisioner == csiProvisionerName
 }
 
+func isLegacyHPPAvailable() bool {
+	hppClient, err := getHPPClient()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	cr, err := hppClient.HostpathprovisionerV1beta1().HostPathProvisioners().Get(context.TODO(), "hostpath-provisioner", metav1.GetOptions{})
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	return cr.Spec.PathConfig != nil
+}

--- a/tests/pvc_test.go
+++ b/tests/pvc_test.go
@@ -31,15 +31,20 @@ import (
 )
 
 const (
-	csiStorageClassName = "hostpath-csi"
-	legacyStorageClassName = "hostpath-provisioner"
+	csiStorageClassName             = "hostpath-csi"
+	legacyStorageClassName          = "hostpath-provisioner"
 	legacyStorageClassNameImmediate = "hostpath-provisioner-immediate"
-	testMountName = "testmount"
+	testMountName                   = "testmount"
 )
+
 func TestCreatePVCOnNode1(t *testing.T) {
 	RegisterTestingT(t)
 	tearDown, ns, k8sClient := setupTestCaseNs(t)
 	defer tearDown(t)
+
+	if !isLegacyHPPAvailable() {
+		t.Skip("Specific node annotation only supported on legacy provisioner which is not available")
+	}
 
 	nodes, err := getAllNodes(k8sClient)
 	Expect(err).ToNot(HaveOccurred())
@@ -133,6 +138,10 @@ func TestCreatePVCWaitForConsumerLegacy(t *testing.T) {
 	tearDown, ns, k8sClient := setupTestCaseNs(t)
 	defer tearDown(t)
 
+	if !isLegacyHPPAvailable() {
+		t.Skip("Do not have legacy HPP provisioner running")
+	}
+
 	createPVCWaitForFirstConsumerTest(legacyStorageClassName, ns, k8sClient, t)
 }
 
@@ -148,8 +157,12 @@ func TestPVCSize(t *testing.T) {
 	RegisterTestingT(t)
 	tearDown, ns, k8sClient := setupTestCaseNs(t)
 	defer tearDown(t)
-	annotations := make(map[string]string)
 
+	if !isLegacyHPPAvailable() {
+		t.Skip("Do not have legacy HPP provisioner running")
+	}
+
+	annotations := make(map[string]string)
 	pvc := createPVCDef(ns.Name, legacyStorageClassName, annotations)
 	defer func() {
 		// Cleanup
@@ -215,8 +228,12 @@ func TestFsGroup(t *testing.T) {
 	RegisterTestingT(t)
 	tearDown, ns, k8sClient := setupTestCaseNs(t)
 	defer tearDown(t)
-	annotations := make(map[string]string)
 
+	if !isLegacyHPPAvailable() {
+		t.Skip("Do not have legacy HPP provisioner running")
+	}
+
+	annotations := make(map[string]string)
 	pvc := createPVCDef(ns.Name, legacyStorageClassName, annotations)
 	defer func() {
 		// Cleanup
@@ -252,7 +269,7 @@ func TestFsGroup(t *testing.T) {
 	Eventually(func() string {
 		getPod, err = k8sClient.CoreV1().Pods(ns.Name).Get(context.TODO(), getPod.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		out ,err := RunKubeCtlCommand("logs", getPod.GetName(), "-n", ns.Name)
+		out, err := RunKubeCtlCommand("logs", getPod.GetName(), "-n", ns.Name)
 		if err != nil {
 			return ""
 		}
@@ -264,8 +281,8 @@ func createPVCDef(namespace, storageClassName string, annotations map[string]str
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "test-pvc",
-			Namespace:   namespace,
-			Annotations: annotations,
+			Namespace:    namespace,
+			Annotations:  annotations,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{
@@ -301,7 +318,7 @@ func createPodUsingPVCWithCommand(namespace, name string, pvc *corev1.Persistent
 					Command: []string{"/bin/sh", "-c", command},
 					VolumeMounts: []v1.VolumeMount{
 						{
-							Name: testMountName,
+							Name:      testMountName,
 							MountPath: "/data",
 						},
 					},
@@ -325,9 +342,9 @@ func createPodUsingPVCWithFsGroup(namespace, name string, pvc *corev1.Persistent
 	userId := int64(1000)
 	pod := createPodUsingPVCWithCommand(namespace, name, pvc, command, annotations)
 	pod.Spec.SecurityContext = &corev1.PodSecurityContext{
-		RunAsUser: &userId,
+		RunAsUser:  &userId,
 		RunAsGroup: &groupId,
-		FSGroup: &groupId,
+		FSGroup:    &groupId,
 	}
 	return pod
 }


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We'd like to run CI against an HPP with a storage pool PVC template
backed by a ceph PVC.

Lane introduced as optional in https://github.com/kubevirt/project-infra/pull/1875.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
- Do we want to skip `TestFsGroup`, `TestPVCSize`
- `TestNodeSelector` now looks for the csi daemonset instead of legacy which will be available in both legacy & CSI-only variations of CR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

