### PR TITLE
Update Go version used in CI to 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ HPP_CSI_IMAGE?=hostpath-csi-driver
 TAG?=latest
 DOCKER_REPO?=kubevirt
 ARTIFACTS_PATH?=_out
-GOLANG_VER?=1.16.8
+GOLANG_VER?=1.18
 
 all: controller hostpath-provisioner
 

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -12,7 +12,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-GOLANG_VER=${GOLANG_VER:-1.16.8}
+GOLANG_VER=${GOLANG_VER:-1.18}
 
 function setGoInProw() {
   if [[ -v PROW_JOB_ID ]] ; then

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -21,7 +21,7 @@ export KUBEVIRT_DEPLOY_PROMETHEUS=true
 make cluster-down
 make cluster-up
 if [[ -v PROW_JOB_ID ]] ; then
-  GOLANG_VER=${GOLANG_VER:-1.16.8}
+  GOLANG_VER=${GOLANG_VER:-1.18}
   eval $(gimme ${GOLANG_VER})
   cp -R ~/.gimme/versions/go${GOLANG_VER}.linux.amd64 /usr/local/go
 fi


### PR DESCRIPTION
Preparation for kubernetes 1.24 which uses Go 1.18, scheduled to be
released in a few days.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update CI to build with Go 1.18
```

