### PR TITLE
Use buildah instead of docker, support multi-arch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,17 @@ DOCKER_REPO?=kubevirt
 ARTIFACTS_PATH?=_out
 GOLANG_VER?=1.18.2
 
+export GOLANG_VER
+export KUBEVIRT_PROVIDER
+export DOCKER_REPO
+
 all: controller hostpath-provisioner
 
 hostpath-provisioner:
-	GOLANG_VER=${GOLANG_VER} ./hack/build-provisioner.sh
+	./hack/build-provisioner.sh
 
 hostpath-csi-driver:
-	GOLANG_VER=${GOLANG_VER} ./hack/build-csi.sh
+	./hack/build-csi.sh
 
 image: image-controller image-csi
 
@@ -52,23 +56,23 @@ clean:
 build: clean hostpath-provisioner hostpath-csi-driver
 
 cluster-up:
-	KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./cluster-up/up.sh
+	./cluster-up/up.sh
 
 cluster-down: 
-	KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./cluster-up/down.sh
+	./cluster-up/down.sh
 
 cluster-sync: cluster-clean
-	KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./cluster-sync/sync.sh
+	./cluster-sync/sync.sh
 
 cluster-clean:
-	KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./cluster-sync/clean.sh
+	./cluster-sync/clean.sh
 
 test:
-	GOLANG_VER=${GOLANG_VER} ./hack/run-unit-test.sh
+	./hack/run-unit-test.sh
 	hack/language.sh
 
 test-functional:
-	KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} gotestsum --format short-verbose --junitfile ${ARTIFACTS_PATH}/junit.functest.xml -- ./tests/... -kubeconfig="../_ci-configs/$(KUBEVIRT_PROVIDER)/.kubeconfig"
+	gotestsum --format short-verbose --junitfile ${ARTIFACTS_PATH}/junit.functest.xml -- ./tests/... -kubeconfig="../_ci-configs/$(KUBEVIRT_PROVIDER)/.kubeconfig"
 
 test-sanity:
-	GOLANG_VER=${GOLANG_VER} DOCKER_REPO=${DOCKER_REPO} hack/sanity.sh
+	hack/sanity.sh

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,18 @@ KUBEVIRT_PROVIDER?=k8s-1.23
 HPP_IMAGE?=hostpath-provisioner
 HPP_CSI_IMAGE?=hostpath-csi-driver
 TAG?=latest
-DOCKER_REPO?=kubevirt
+DOCKER_REPO?=quay.io/kubevirt
 ARTIFACTS_PATH?=_out
 GOLANG_VER?=1.18.2
+GOOS?=linux
+GOARCH?=amd64
+BUILDAH_PLATFORM_FLAG?=--platform $(GOOS)/$(GOARCH)
 
 export GOLANG_VER
 export KUBEVIRT_PROVIDER
 export DOCKER_REPO
+export GOOS
+export GOARCH
 
 all: controller hostpath-provisioner
 
@@ -36,22 +41,38 @@ hostpath-csi-driver:
 
 image: image-controller image-csi
 
-push: push-controller push-csi
+push: clean manifest manifest-push
 
-push-controller: hostpath-provisioner image
-	docker push $(DOCKER_REPO)/$(HPP_IMAGE):$(TAG)
+manifest: manifest-controller manifest-csi
+
+manifest-push: push-csi push-controller
 
 image-controller: hostpath-provisioner
-	docker build -t $(DOCKER_REPO)/$(HPP_IMAGE):$(TAG) -f Dockerfile.controller .
+	buildah build $(BUILDAH_PLATFORM_FLAG) -t $(DOCKER_REPO)/$(HPP_IMAGE):$(GOARCH) -f Dockerfile.controller .
 
 image-csi: hostpath-csi-driver
-	docker build -t $(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(TAG) -f Dockerfile.csi .
+	buildah build $(BUILDAH_PLATFORM_FLAG) -t $(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(GOARCH) -f Dockerfile.csi .
 
-push-csi: hostpath-csi-driver image-csi
-	docker push $(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(TAG)
+manifest-controller: image-controller
+	-buildah manifest create $(DOCKER_REPO)/$(HPP_IMAGE):local
+	buildah manifest add --arch $(GOARCH) $(DOCKER_REPO)/$(HPP_IMAGE):local containers-storage:$(DOCKER_REPO)/$(HPP_IMAGE):$(GOARCH)
 
-clean:
+manifest-csi: image-csi
+	-buildah manifest create $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local
+	buildah manifest add --arch $(GOARCH) $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local containers-storage:$(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(GOARCH)
+
+push-csi:
+	buildah manifest push $(BUILDAH_PUSH_FLAGS) --all $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local docker://$(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(TAG)
+
+push-controller:
+	buildah manifest push $(BUILDAH_PUSH_FLAGS) --all $(DOCKER_REPO)/$(HPP_IMAGE):local docker://$(DOCKER_REPO)/$(HPP_IMAGE):$(TAG)
+
+clean: manifest-clean
 	rm -rf _out
+
+manifest-clean:
+	-buildah manifest rm $(DOCKER_REPO)/$(HPP_IMAGE):local
+	-buildah manifest rm $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local
 
 build: clean hostpath-provisioner hostpath-csi-driver
 

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,14 @@ GOLANG_VER?=1.18.2
 GOOS?=linux
 GOARCH?=amd64
 BUILDAH_PLATFORM_FLAG?=--platform $(GOOS)/$(GOARCH)
+OCI_BIN ?= $(shell if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
 
 export GOLANG_VER
 export KUBEVIRT_PROVIDER
 export DOCKER_REPO
 export GOOS
 export GOARCH
+export OCI_BIN
 
 all: controller hostpath-provisioner
 

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -27,7 +27,7 @@ for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
 done
 
 registry=${IMAGE_REGISTRY:-localhost:$(_port registry)}
-DOCKER_REPO=${registry} make push
+DOCKER_REPO=${registry} BUILDAH_PUSH_FLAGS="--tls-verify=false" make manifest manifest-push
 
 if [ ! -z $UPGRADE_FROM ]; then
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$UPGRADE_FROM/namespace.yaml

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -27,7 +27,11 @@ for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
 done
 
 registry=${IMAGE_REGISTRY:-localhost:$(_port registry)}
-DOCKER_REPO=${registry} BUILDAH_PUSH_FLAGS="--tls-verify=false" make manifest manifest-push
+if [[ ${registry} == localhost* ]]; then
+  echo "not verifying tls, registry contains localhost"
+  export BUILDAH_PUSH_FLAGS="--tls-verify=false"
+fi
+DOCKER_REPO=${registry} make manifest manifest-push
 
 if [ ! -z $UPGRADE_FROM ]; then
   _kubectl apply -f https://github.com/kubevirt/hostpath-provisioner-operator/releases/download/$UPGRADE_FROM/namespace.yaml

--- a/hack/k8s-e2e.sh
+++ b/hack/k8s-e2e.sh
@@ -62,7 +62,11 @@ fi
 echo "install hpp"
 registry=${IMAGE_REGISTRY:-localhost:$(_port registry)}
 echo "registry: ${registry}"
-DOCKER_REPO=${registry} BUILDAH_PUSH_FLAGS="--tls-verify=false" make manifest manifest-push
+if [[ ${registry} == localhost* ]]; then
+  echo "not verifying tls, registry contains localhost"
+  export BUILDAH_PUSH_FLAGS="--tls-verify=false"
+fi
+DOCKER_REPO=${registry} make manifest manifest-push
 
 #install hpp
 _kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/namespace.yaml

--- a/hack/k8s-e2e.sh
+++ b/hack/k8s-e2e.sh
@@ -62,7 +62,7 @@ fi
 echo "install hpp"
 registry=${IMAGE_REGISTRY:-localhost:$(_port registry)}
 echo "registry: ${registry}"
-DOCKER_REPO=${registry} make push
+DOCKER_REPO=${registry} BUILDAH_PUSH_FLAGS="--tls-verify=false" make manifest manifest-push
 
 #install hpp
 _kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/namespace.yaml

--- a/hack/sanity.sh
+++ b/hack/sanity.sh
@@ -19,7 +19,7 @@ source "${script_dir}"/common.sh
 setGoInProw $GOLANG_VER
 
 echo "docker repo: [$DOCKER_REPO]"
-go test -o _out/sanity.test -c -v ./sanity/...
+CGO_ENABLED=0 go test -o _out/sanity.test -c -v ./sanity/...
 docker build -t ${DOCKER_REPO}/sanity:test -f ./sanity/Dockerfile .
 # Need privileged so we can bind mount inside container, and hostpath capacity cannot change, so skipping that test
 docker run --privileged ${DOCKER_REPO}/sanity:test -ginkgo.noColor -ginkgo.skip="should fail when requesting to create a volume with already existing name and different capacity"

--- a/hack/sanity.sh
+++ b/hack/sanity.sh
@@ -20,7 +20,7 @@ setGoInProw $GOLANG_VER
 
 echo "docker repo: [$DOCKER_REPO]"
 CGO_ENABLED=0 go test -o _out/sanity.test -c -v ./sanity/...
-docker build -t ${DOCKER_REPO}/sanity:test -f ./sanity/Dockerfile .
+buildah build -t ${DOCKER_REPO}/sanity:test -f ./sanity/Dockerfile .
 # Need privileged so we can bind mount inside container, and hostpath capacity cannot change, so skipping that test
-docker run --privileged ${DOCKER_REPO}/sanity:test -ginkgo.noColor -ginkgo.skip="should fail when requesting to create a volume with already existing name and different capacity"
+podman run --privileged ${DOCKER_REPO}/sanity:test -ginkgo.noColor -ginkgo.skip="should fail when requesting to create a volume with already existing name and different capacity"
 

--- a/hack/sanity.sh
+++ b/hack/sanity.sh
@@ -20,7 +20,7 @@ setGoInProw $GOLANG_VER
 
 echo "docker repo: [$DOCKER_REPO]"
 CGO_ENABLED=0 go test -o _out/sanity.test -c -v ./sanity/...
-buildah build -t ${DOCKER_REPO}/sanity:test -f ./sanity/Dockerfile .
+$OCI_BIN build -t ${DOCKER_REPO}/sanity:test -f ./sanity/Dockerfile .
 # Need privileged so we can bind mount inside container, and hostpath capacity cannot change, so skipping that test
-podman run --privileged ${DOCKER_REPO}/sanity:test -ginkgo.noColor -ginkgo.skip="should fail when requesting to create a volume with already existing name and different capacity"
+$OCI_BIN run --privileged ${DOCKER_REPO}/sanity:test -ginkgo.noColor -ginkgo.skip="should fail when requesting to create a volume with already existing name and different capacity"
 


### PR DESCRIPTION
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
hostpath-provisioner part of #98, we also need to change `make push` in project-infra to build arm64 binaries.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use buildah and podman, enable building multi-arch manifests
```

