### PR TITLE
Update manifests for deploying the CSI driver

### DIFF
--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -25,6 +25,10 @@ import (
 	"kubevirt.io/hostpath-provisioner/pkg/hostpath"
 )
 
+const (
+	defaultDatadirTuple = `[{"name": "local", "path": "/csi-data-dir"}]`
+)
+
 func init() {
 }
 
@@ -36,7 +40,7 @@ func main() {
 	flag.Set("logtostderr", "true")
 	flag.StringVar(&cfg.Endpoint, "endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	flag.StringVar(&cfg.DriverName, "drivername", "hostpath.csi.kubevirt.io", "name of the driver")
-	flag.StringVar(&dataDir, "datadir", "/csi-data-dir", "storage pool name/path tupels that indicate which storage pool name is associated with which path, in JSON format. Example: [{\"name\":\"local\",\"path\":\"/var/hpvolumes\"}]")
+	flag.StringVar(&dataDir, "datadir", defaultDatadirTuple, "storage pool name/path tupels that indicate which storage pool name is associated with which path, in JSON format. Example: [{\"name\":\"local\",\"path\":\"/var/hpvolumes\"}]")
 	flag.StringVar(&cfg.NodeID, "nodeid", "", "node id")
 	flag.StringVar(&cfg.Version, "version", "", "version of the plugin")
 	flag.Parse()

--- a/deploy/csi/csi-sc.yaml
+++ b/deploy/csi/csi-sc.yaml
@@ -3,4 +3,6 @@ kind: StorageClass
 metadata:
   name: csi-hostpath-provisioner
 provisioner: kubevirt.io.hostpath-provisioner
+parameters:
+  storagePool: local
 volumeBindingMode: WaitForFirstConsumer

--- a/deploy/kubevirt-hostpath-security-constraints-csi.yaml
+++ b/deploy/kubevirt-hostpath-security-constraints-csi.yaml
@@ -1,5 +1,5 @@
 kind: SecurityContextConstraints
-apiVersion: v1
+apiVersion: security.openshift.io/v1
 metadata:
   name: hostpath-provisioner
 allowPrivilegedContainer: true
@@ -16,6 +16,8 @@ fsGroup:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
-allowHostDirVolumePlugin: false
+allowHostDirVolumePlugin: true
+readOnlyRootFilesystem: false
+allowHostNetwork: true
 users:
 - system:serviceaccount:kubevirt-hostpath-provisioner:kubevirt-hostpath-provisioner-admin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: This updates the `StorageClass` and `SecurityContextConstraints` manifest files for deploying the CSI driver, adds some missing permissions that are needed by the daemonSet and a missing argument to the CSI provisioner in the `StorageClass` manifest

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

