### PR TITLE
Ensure correct go with functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test:
 	hack/language.sh
 
 test-functional:
-	gotestsum --format short-verbose --junitfile ${ARTIFACTS_PATH}/junit.functest.xml -- ./tests/... -kubeconfig="../_ci-configs/$(KUBEVIRT_PROVIDER)/.kubeconfig"
+	hack/run-functional-test.sh
 
 test-sanity:
 	hack/sanity.sh

--- a/hack/run-functional-test.sh
+++ b/hack/run-functional-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#Copyright 2021 The hostpath provisioner Authors.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
+KUBEVIRT_PROVIDER=k8s-1.25
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+source "${script_dir}"/common.sh
+setGoInProw $GOLANG_VER
+
+echo "** $KUBEVIRT_PROVIDER **"
+go version
+gotestsum --format short-verbose --junitfile ${ARTIFACTS_PATH}/junit.functest.xml -- ./tests/... -kubeconfig="$PWD/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig"


### PR DESCRIPTION
The wrong go version was running during the functional tests, causing the tests to fail on newer runtime
library.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

