### PR TITLE
Single point for k8s version in makefile

### DIFF
--- a/cluster-sync/clean.sh
+++ b/cluster-sync/clean.sh
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-"k8s-1.25"}
-
 source ./cluster-up/hack/common.sh
 source ./cluster-up/cluster/${KUBEVIRT_PROVIDER}/provider.sh
 

--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-"k8s-1.25"}
 KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 HPP_NAMESPACE=${HPP_NAMESPACE:-"hostpath-provisioner"}
 

--- a/hack/k8s-e2e.sh
+++ b/hack/k8s-e2e.sh
@@ -17,7 +17,6 @@ source ./cluster-up/hack/common.sh
 source ./cluster-up/cluster/${KUBEVIRT_PROVIDER}/provider.sh
 
 export KUBEVIRT_NUM_NODES=2
-export KUBEVIRT_PROVIDER=k8s-1.25
 make cluster-down
 make cluster-up
 
@@ -87,8 +86,10 @@ export KUBE_SSH_KEY_PATH=./vagrant.key
 export KUBE_SSH_USER=vagrant
 
 echo "KUBE_SSH_USER=${KUBE_SSH_USER}, KEY_FILE=${KUBE_SSH_KEY_PATH}"
+k8s_version=$(_kubectl version -o json | jq ".serverVersion.gitVersion" -r)
+echo "Downloading test for version $k8s_version"
 #Download test
-curl --location https://dl.k8s.io/v1.25.0/kubernetes-test-linux-amd64.tar.gz |   tar --strip-components=3 -zxf - kubernetes/test/bin/e2e.test kubernetes/test/bin/ginkgo
+curl --location https://dl.k8s.io/${k8s_version}/kubernetes-test-linux-amd64.tar.gz |   tar --strip-components=3 -zxf - kubernetes/test/bin/e2e.test kubernetes/test/bin/ginkgo
 #Run test
 # Some of these tests assume immediate binding, which is a random node, however if multiple volumes are involved sometimes they end up on different nodes and the test fails. Excluding that test.
 ./e2e.test -ginkgo.v -ginkgo.focus='External.Storage.*kubevirt.io.hostpath-provisioner' -ginkgo.skip='immediate binding|External.Storage.*should access to two volumes with the same volume mode and retain data across pod recreation on the same node \[LinuxOnly\]' -storage.testdriver=./hack/test-driver.yaml -provider=local

--- a/hack/run-functional-test.sh
+++ b/hack/run-functional-test.sh
@@ -14,7 +14,6 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-KUBEVIRT_PROVIDER=k8s-1.25
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 setGoInProw $GOLANG_VER

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -16,7 +16,6 @@
 set -e
 readonly ARTIFACTS_PATH="${ARTIFACTS}"
 export KUBEVIRT_NUM_NODES=2
-export KUBEVIRT_PROVIDER=k8s-1.25
 export KUBEVIRT_DEPLOY_PROMETHEUS=true
 make cluster-down
 make cluster-up


### PR DESCRIPTION
Make it simpler to upgrade k8s

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Updating k8s version to run against was painful and error prone. This PR takes the version we want from a single point, and propagates it everywhere. This way updating should be a matter of changing the Makefile

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

