### PR TITLE
Replace deprecated k8s registry references

### DIFF
--- a/deploy/csi/csi-kubevirt-hostpath-provisioner.yaml
+++ b/deploy/csi/csi-kubevirt-hostpath-provisioner.yaml
@@ -136,7 +136,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0
+        image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.3.0
         imagePullPolicy: IfNotPresent
         name: csi-external-health-monitor-controller
         resources: {}
@@ -155,7 +155,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
         imagePullPolicy: IfNotPresent
         name: node-driver-registrar
         resources: {}
@@ -173,7 +173,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --health-port=9898
-        image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources: {}
@@ -208,7 +208,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
+        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.1
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
         resources: {}

--- a/deploy/tests/operator.yaml
+++ b/deploy/tests/operator.yaml
@@ -1899,12 +1899,12 @@ spec:
             - name: CSI_PROVISIONER_IMAGE
               value: "registry:5000/hostpath-csi-driver:latest"
             - name: EXTERNAL_HEALTH_MON_IMAGE
-              value: "k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0"
+              value: "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.3.0"
             - name: NODE_DRIVER_REG_IMAGE
-              value: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"
+              value: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0"
             - name: LIVENESS_PROVE_IMAGE
-              value: "k8s.gcr.io/sig-storage/livenessprobe:v2.3.0"
+              value: "registry.k8s.io/sig-storage/livenessprobe:v2.3.0"
             - name: CSI_SIG_STORAGE_PROVISIONER_IMAGE
-              value: "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1"
+              value: "registry.k8s.io/sig-storage/csi-provisioner:v2.2.1"
             - name: VERBOSITY
               value: "3"


### PR DESCRIPTION
**What this PR does / why we need it**:

Problem: Previously all of Kubernetes' image hosting has been out of gcr.io. There were significant egress costs associated with this when images were pulled from entities outside gcp. Refer to https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Solution: As highlighted at KubeCon NA 2022 k8s infra SIG update, the replacement for k8s.gcr.io which is registry.k8s.io is now ready for mainstream use and the old k8s.gcr.io has been formally deprecated and projects are requested to migrate off it. This commit migrates remaining references for `kubevirt/hostpath-provisioner` to registry.k8s.io.


**Which issue(s) this PR fixes**
Relates to umbrella issue https://github.com/kubernetes/k8s.io/issues/4780


**Special notes for your reviewer**:
I've verified that these images exist in `registry.k8s.io`.

**Release note**:
```release-note
NONE
```

