### PR TITLE
[release-v0.12] Remove empty -extldflags

### DIFF
--- a/hack/build-csi.sh
+++ b/hack/build-csi.sh
@@ -18,4 +18,4 @@ script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 setGoInProw $GOLANG_VER
 
-CGO_ENABLED=1 go build -a -tags strictfipsruntime -ldflags '-extldflags' -o _out/hostpath-csi-driver cmd/plugin/plugin.go
+CGO_ENABLED=1 go build -a -tags strictfipsruntime -o _out/hostpath-csi-driver cmd/plugin/plugin.go

--- a/hack/build-provisioner.sh
+++ b/hack/build-provisioner.sh
@@ -17,4 +17,4 @@ script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 setGoInProw $GOLANG_VER
 go mod vendor
-CGO_ENABLED=1 go build -a -tags strictfipsruntime -ldflags '-extldflags' -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go
+CGO_ENABLED=1 go build -a -tags strictfipsruntime -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go


### PR DESCRIPTION
We removed the static flag but having an empty extldflags is causing issues for some compiler. Since it is not needed removing completely

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual backport of #219 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

