### PR TITLE
Disable dynamic linking for non amd64 compiling

### DIFF
--- a/hack/build-csi.sh
+++ b/hack/build-csi.sh
@@ -17,5 +17,11 @@
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 setGoInProw $GOLANG_VER
+if [ "${GOARCH}" != "amd64" ]; then
+  #disable dynamic linking for non amd64 architectures. Don't have a proper cross compiler to make this
+  #work. In particular can't find a glibc that can be installed.
+  CGO_ENABLED=0 go build -a -o _out/hostpath-csi-driver cmd/plugin/plugin.go
+else
+  CGO_ENABLED=1 go build -a -tags strictfipsruntime -o _out/hostpath-csi-driver cmd/plugin/plugin.go
+fi
 
-CGO_ENABLED=1 go build -a -tags strictfipsruntime -o _out/hostpath-csi-driver cmd/plugin/plugin.go

--- a/hack/build-provisioner.sh
+++ b/hack/build-provisioner.sh
@@ -16,5 +16,10 @@
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 setGoInProw $GOLANG_VER
-
-CGO_ENABLED=1 go build -a -tags strictfipsruntime -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go
+if [ "${GOARCH}" != "amd64" ]; then
+  #disable dynamic linking for non amd64 architectures. Don't have a proper cross compiler to make this
+  #work. In particular can't find a glibc that can be installed.
+  CGO_ENABLED=0 go build -a -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go
+else
+  CGO_ENABLED=1 go build -a -tags strictfipsruntime -o _out/hostpath-provisioner cmd/provisioner/hostpath-provisioner.go
+fi

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -18,9 +18,6 @@ function setGoInProw() {
   if [[ -v PROW_JOB_ID ]] ; then
     export GIMME_HOSTARCH=amd64
     export GIMME_ARCH=${GOARCH}
-    if [ "${GOARCH}" == "arm64" ]; then
-        dnf install -y gcc-aarch64-linux-gnu
-    fi
     eval $(gimme ${1})
     cp -R ~/.gimme/versions/go${1}.linux.amd64 /usr/local/go
   fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Disable dynamic linking when cross compiling for other architectures. The cross compile fails to find the appropriate libraries and it is causing releases to fail. This disables dynamic linking for the other architectures allowing releases to work again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

