### PR TITLE
fix csi plugin invalid default value

### DIFF
--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -36,7 +36,7 @@ func main() {
 	flag.Set("logtostderr", "true")
 	flag.StringVar(&cfg.Endpoint, "endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	flag.StringVar(&cfg.DriverName, "drivername", "hostpath.csi.kubevirt.io", "name of the driver")
-	flag.StringVar(&dataDir, "datadir", "/csi-data-dir", "storage pool name/path tupels that indicate which storage pool name is associated with which path, in JSON format. Example: [{\"name\":\"local\",\"path\":\"/var/hpvolumes\"}]")
+	flag.StringVar(&dataDir, "datadir", "[{\"name\":\"legacy\",\"path\":\"/csi-data-dir\"}]", "storage pool name/path tupels that indicate which storage pool name is associated with which path, in JSON format. Example: [{\"name\":\"legacy\",\"path\":\"/csi-data-dir\"}]")
 	flag.StringVar(&cfg.NodeID, "nodeid", "", "node id")
 	flag.StringVar(&cfg.Version, "version", "", "version of the plugin")
 	flag.Parse()

--- a/deploy/csi/csi-kubevirt-hostpath-provisioner.yaml
+++ b/deploy/csi/csi-kubevirt-hostpath-provisioner.yaml
@@ -84,6 +84,7 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --nodeid=$(NODE_NAME)
         - --version=$(VERSION)
+        - --datadir=[{"name":"legacy","path":"/csi-data-dir"}]
         env:
         - name: CSI_ENDPOINT
           value: unix:///csi/csi.sock


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
the csi plugin parameter `datadir`'s default value is invalid, can not parse to `StoragePoolInfo`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
fixes #251 

**Special notes for your reviewer**:
none

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

