### PR TITLE
[release-v0.15] Recreate go.sum to fix mismatch

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1410,7 +1410,7 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20221107191617-1a15be271d1d/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 h1:KTgPnR10d5zhztWptI952TNtt/4u5h3IzDXkdIMuo2Y=
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-kubevirt.io/hostpath-provisioner-operator v0.15.0 h1:VBgtSv5It7JMP3237813+KUR7WFClY7pQaIkaS20z74=
+kubevirt.io/hostpath-provisioner-operator v0.15.0 h1:5KokKTXU6P51Kc159U7dd9gKkTu57M1WrjFM/yW4Kx4=
 kubevirt.io/hostpath-provisioner-operator v0.15.0/go.mod h1:BkaYZUxIJFFrG6tcrzwqWGP+nLd4yLckh4/SF/UiWqw=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
```
verifying kubevirt.io/hostpath-provisioner-operator@v0.15.0: checksum mismatch
	downloaded: h1:5KokKTXU6P51Kc159U7dd9gKkTu57M1WrjFM/yW4Kx4=
	go.sum:     h1:VBgtSv5It7JMP3237813+KUR7WFClY7pQaIkaS20z74=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: malformed go.sum for current deps
```

