### PR TITLE
Remove last remnant of specifying golang version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,11 @@ HPP_CSI_IMAGE?=hostpath-csi-driver
 TAG?=latest
 DOCKER_REPO?=quay.io/kubevirt
 ARTIFACTS_PATH?=_out
-GOLANG_VER?=1.20.10
 GOOS?=linux
 GOARCH?=amd64
 BUILDAH_PLATFORM_FLAG?=--platform $(GOOS)/$(GOARCH)
 OCI_BIN ?= $(shell if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
 
-export GOLANG_VER
 export KUBEVIRT_PROVIDER
 export DOCKER_REPO
 export GOOS

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -19,11 +19,6 @@ export KUBEVIRT_NUM_NODES=2
 export KUBEVIRT_DEPLOY_PROMETHEUS=true
 make cluster-down
 make cluster-up
-if [[ -v PROW_JOB_ID ]] ; then
-  GOLANG_VER=${GOLANG_VER:-1.20.10}
-  eval $(gimme ${GOLANG_VER})
-  cp -R ~/.gimme/versions/go${GOLANG_VER}.linux.amd64 /usr/local/go
-fi
 
 go install gotest.tools/gotestsum@latest
 #export UPGRADE_FROM=$(curl -s https://github.com/kubevirt/hostpath-provisioner-operator/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Use the golang in the build container instead of specifying a specific version. This allows us to update the builder and keep up with the latest go version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

