### PR TITLE
Fix runbook_url test

### DIFF
--- a/tests/prometheus_test.go
+++ b/tests/prometheus_test.go
@@ -315,8 +315,8 @@ func checkRequiredAnnotations(rule monitoringv1.Rule) {
 		"%s summary is missing or empty", rule.Alert)
 	Expect(rule.Annotations).To(HaveKey("runbook_url"),
 		"%s runbook_url is missing", rule.Alert)
-	Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", HaveSuffix(rule.Alert)),
-		"%s runbook_url is not equal to alert name", rule.Alert)
+	Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", ContainSubstring(rule.Alert)),
+		"%s runbook_url doesn't include alert name", rule.Alert)
 	resp, err := http.Head(rule.Annotations["runbook_url"])
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), fmt.Sprintf("%s runbook is not available", rule.Alert))
 	ExpectWithOffset(1, resp.StatusCode).Should(Equal(http.StatusOK), fmt.Sprintf("%s runbook is not available", rule.Alert))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

What this PR does / why we need it:
Fix runbook_url test to not expect the alert name as the URL suffix, as in some installations the alert name is not the URL suffix.
e.g. in openshift the runbooks are in https://github.com/openshift/runbooks/tree/master/alerts/openshift-virtualization-operator, and the suffix is `<alert-name>.md`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

