### PR TITLE
fix: execute functional tests from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test:
 	hack/language.sh
 
 test-functional:
-	hack/run-functional-test.sh
+	ARTIFACTS_PATH=$(ARTIFACTS_PATH) hack/run-functional-test.sh
 
 test-sanity: generate-doc lint-metrics
 	hack/sanity.sh


### PR DESCRIPTION
The `ARTIFACTS_PATH` variable was not passed to the `run-functional-test` script.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x common-templates testing

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

