### PR TITLE
fix: lint-metrics scripts

### DIFF
--- a/hack/prom_metric_linter.sh
+++ b/hack/prom_metric_linter.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 
 linter_image_tag="v0.0.3"


### PR DESCRIPTION
The prom_metric_linter.sh script was missing a shebang line, which caused the lint-metrics make task to fail in certain configurations.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x test for common-templates

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

