### PR TITLE
feat: add custom renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["main"],
+  "prConcurrentLimit": 3,
+  "lockFileMaintenance": {
+    "enabled": false
+  },
+  "postUpdateOptions": ["gomodTidy"],
+  "labels": ["release-note-none"],
+  "extends": [":gitSignOff", ":dependencyDashboard"],
+  "packageRules": [
+    {
+      "groupName": "all dependencies",
+      "groupSlug": "all",
+      "enabled": false,
+      "matchPackageNames": [
+        "*"
+      ]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "assigneesFromCodeOwners": true,
+  "separateMajorMinor": true,
+  "ignorePaths": [
+    "**/vendor/**",
+    "**/cluster-up/**"
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add custom renovate config

This PR add a custom renovate config. It disables regular dependency bumping and keeps only security patches enabled. It will also open a new issue with dependency graph.

**Release note**:
```
Add custom renovate configuration
```

