### PR TITLE
[release 0.22] revert toolchain update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module kubevirt.io/hostpath-provisioner
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.23.7
 
 require (
 	github.com/container-storage-interface/spec v1.9.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The tool chain was updated to 1.24 while the go version is still at 1.23. We are not yet ready
for golang 1.24, so reverting to 1.23 toolchain as well

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

