### PR TITLE
fix recording rule to correct name

### DIFF
--- a/tests/prometheus_test.go
+++ b/tests/prometheus_test.go
@@ -48,7 +48,7 @@ const (
 	prometheusCRDName        = "prometheuses.monitoring.coreos.com"
 	prometheusSaName         = "prometheus-k8s"
 	prometheusSaSecretPrefix = "prometheus-k8s-token"
-	operatorUpQueryName      = "kubevirt_hpp_operator_up"
+	operatorUpQueryName      = "cluster:kubevirt_hpp_operator_up:sum"
 	hppCRReadyQueryName      = "kubevirt_hpp_cr_ready"
 	hppPoolSharedQueryName   = "kubevirt_hpp_pool_path_shared_with_os"
 	promRuleOperatorUp       = "1"


### PR DESCRIPTION
This pr is a follow-up of https://github.com/kubevirt/hostpath-provisioner-operator/pull/654 and should be merged only after hostpath-provisioner-operator is merged.

jira-ticket: https://issues.redhat.com/browse/CNV-71479

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubevirt_hpp_operator_up is deprecated in favor of cluster:kubevirt_hpp_operator_up:sum, in order to comply with the recording rules naming conventions.
```

