### PR TITLE
Add s390x architecture support

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -34,8 +34,11 @@ x86_64* | i?86_64* | amd64*)
 aarch64* | arm64*)
     ARCH="arm64"
     ;;
+s390x*)
+    ARCH="s390x"
+    ;;
 *)
-    echo "invalid Arch, only support x86_64 and aarch64"
+    echo "invalid Arch, only support x86_64, aarch64 and s390x"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
- Adds s390x to the architecture detection in `cluster-up/cluster/kind/common.sh`, enabling local dev/test on s390x systems
- Part of adding s390x to the multi-arch offering (closes #388)
- Companion PR: kubevirt/project-infra#4772 (adds `GOARCH=s390x make manifest` to postsubmit jobs)

## Notes
- No code changes needed in the build system — the Makefile and build scripts already handle arbitrary `GOARCH` values
- Base image (`fedora-minimal:42`) already publishes s390x images
- `kind` has s390x binaries available since v0.14.0

## Test plan
- [x] `GOARCH=s390x make hostpath-provisioner` produces a valid static binary
- [x] `GOARCH=s390x make hostpath-csi-driver` produces a valid static binary
- [x] Existing unit tests (`make test`) continue to pass (architecture-independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)