### PR TITLE
Allow daemonset metrics to be served over HTTPS

### DIFF
--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -32,6 +32,9 @@ func main() {
 	defer klog.Flush()
 	cfg := &hostpath.Config{}
 	var dataDir string
+	var metricsCertFile string
+	var metricsKeyFile string
+	var metricsTLSVersion string
 	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 	flag.StringVar(&cfg.Endpoint, "endpoint", "unix://tmp/csi.sock", "CSI endpoint")
@@ -39,10 +42,13 @@ func main() {
 	flag.StringVar(&dataDir, "datadir", "[{\"name\":\"legacy\",\"path\":\"/csi-data-dir\",\"snapshotPath\":\"/snap-dir\", \"snapshotProvider\":\"reflink\"}]", "storage pool array with each entry including, storage pool name, directory path, and optional snapshot directory path and snapshot provider, all of this in JSON format. Example: [{\"name\":\"legacy\",\"path\":\"/csi-data-dir\",\"snapshotPath\":\"/snap-dir\",\"snapshotProvider\":\"reflink\"}]")
 	flag.StringVar(&cfg.NodeID, "nodeid", "", "node id")
 	flag.StringVar(&cfg.Version, "version", "", "version of the plugin")
+	flag.StringVar(&metricsCertFile, "metrics-cert-file", "", "path to TLS certificate file for metrics server (optional, will use self-signed cert if not provided). Note: self-signed certs only include localhost+127.0.0.1 by default; set POD_IP (most important), POD_NAMESPACE, and SERVICE_NAME env vars for in-cluster SANs needed for certificate verification")
+	flag.StringVar(&metricsKeyFile, "metrics-key-file", "", "path to TLS key file for metrics server (optional, will use self-signed cert if not provided)")
+	flag.StringVar(&metricsTLSVersion, "metrics-tls-version", "VersionTLS13", "minimum TLS version for metrics server (VersionTLS10, VersionTLS11, VersionTLS12, or VersionTLS13)")
 	flag.Parse()
 
 	klog.V(1).Info("Starting Prometheus metrics endpoint server")
-	hostpath.RunPrometheusServer(":8080")
+	hostpath.RunPrometheusServer(":8443", metricsCertFile, metricsKeyFile, metricsTLSVersion)
 
 	klog.V(1).Infof("Starting new HostPathDriver, config: %v", *cfg)
 	ctx := signals.SetupSignalHandler()

--- a/pkg/hostpath/tls.go
+++ b/pkg/hostpath/tls.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The hostpath provisioner Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package hostpath
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/klog/v2"
+)
+
+// generateSelfSignedCert generates a self-signed certificate for the metrics server.
+//
+// Default SANs (always included):
+//   - DNS: localhost
+//   - IP: 127.0.0.1
+//
+// Additional SANs (if environment variables are set, typically via downward API):
+//   - POD_IP: adds pod IP address (most reliable for Endpoints-based scraping)
+//   - POD_IP + POD_NAMESPACE: adds IP-based pod DNS (e.g., 10-244-0-5.default.pod.cluster.local)
+//   - SERVICE_NAME + POD_NAMESPACE: adds service DNS names (*.svc, *.svc.cluster.local)
+//
+// IMPORTANT: Without the additional environment variables, certificate verification will fail
+// for clients that verify the server certificate. These env vars should be set via the downward
+// API if TLS verification is required.
+//
+// NOTE: For most in-cluster clients, the pod IP SAN is sufficient since they typically connect
+// via pod IPs directly (e.g., Endpoints). Service DNS is included for service-based connections.
+func generateSelfSignedCert() (tls.Certificate, error) {
+	// Collect IP addresses
+	ips := []net.IP{{127, 0, 0, 1}} // localhost
+
+	// Try to get pod IP from environment (set by downward API)
+	// This is the most reliable SAN for Endpoints-based Prometheus scraping
+	podIP := os.Getenv("POD_IP")
+	var ipWithDashes string
+	if podIP != "" {
+		if ip := net.ParseIP(podIP); ip != nil {
+			ips = append(ips, ip)
+			klog.V(3).Infof("Added pod IP %s to certificate SANs", podIP)
+
+			// Generate IP-with-dashes format for Kubernetes pod DNS
+			// IPv4: 10.244.0.5 → 10-244-0-5
+			// IPv6: 2001:db8::1 → 2001-db8--1
+			if ip.To4() != nil {
+				// IPv4: replace dots with dashes
+				ipWithDashes = strings.ReplaceAll(podIP, ".", "-")
+			} else {
+				// IPv6: replace colons with dashes
+				ipWithDashes = strings.ReplaceAll(podIP, ":", "-")
+			}
+		}
+	}
+
+	// Collect DNS names for common in-cluster scraping patterns
+	dnsNames := []string{"localhost"}
+
+	// Add IP-based pod DNS pattern (the standard Kubernetes pattern)
+	// Format: <ip-with-dashes>.<namespace>.pod.cluster.local
+	podNamespace := os.Getenv("POD_NAMESPACE")
+	if ipWithDashes != "" && podNamespace != "" {
+		dnsNames = append(dnsNames, fmt.Sprintf("%s.%s.pod.cluster.local", ipWithDashes, podNamespace))
+		klog.V(3).Infof("Added IP-based pod DNS: %s.%s.pod.cluster.local", ipWithDashes, podNamespace)
+	}
+
+	// Add service-based DNS patterns if SERVICE_NAME is available
+	serviceName := os.Getenv("SERVICE_NAME")
+	if serviceName != "" && podNamespace != "" {
+		// Service FQDN: <service-name>.<namespace>.svc.cluster.local
+		dnsNames = append(dnsNames, serviceName)
+		dnsNames = append(dnsNames, fmt.Sprintf("%s.%s", serviceName, podNamespace))
+		dnsNames = append(dnsNames, fmt.Sprintf("%s.%s.svc", serviceName, podNamespace))
+		dnsNames = append(dnsNames, fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, podNamespace))
+	}
+
+	klog.V(3).Infof("Generating self-signed certificate with DNS SANs: %s", strings.Join(dnsNames, ", "))
+
+	// Generate self-signed certificate
+	// Note: Using self-signed certificates here should be good enough. It's just important that we
+	// encrypt the communication. For example kube-controller-manager also uses a self-signed certificate
+	// for metrics.
+	cert, key, err := certutil.GenerateSelfSignedCertKey("localhost", ips, dnsNames)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to generate self-signed certificate: %w", err)
+	}
+
+	keyPair, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to create self-signed key pair: %w", err)
+	}
+
+	return keyPair, nil
+}

--- a/pkg/hostpath/tls_test.go
+++ b/pkg/hostpath/tls_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2026 The hostpath provisioner Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostpath
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_generateSelfSignedCert(t *testing.T) {
+	RegisterTestingT(t)
+
+	t.Run("generates valid certificate with localhost SANs", func(t *testing.T) {
+		// Clear environment variables
+		os.Unsetenv("POD_IP")
+		os.Unsetenv("POD_NAMESPACE")
+		os.Unsetenv("SERVICE_NAME")
+
+		cert, err := generateSelfSignedCert()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cert.Certificate).ToNot(BeEmpty())
+
+		// Parse the certificate to verify SANs
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		// Should have localhost DNS name
+		Expect(x509Cert.DNSNames).To(ContainElement("localhost"))
+
+		// Should have 127.0.0.1 IP (compare string representation)
+		hasLocalhost := false
+		for _, ip := range x509Cert.IPAddresses {
+			if ip.String() == "127.0.0.1" {
+				hasLocalhost = true
+				break
+			}
+		}
+		Expect(hasLocalhost).To(BeTrue(), "certificate should include 127.0.0.1")
+	})
+
+	t.Run("includes pod IP when POD_IP is set", func(t *testing.T) {
+		os.Setenv("POD_IP", "10.244.0.5")
+		defer os.Unsetenv("POD_IP")
+
+		cert, err := generateSelfSignedCert()
+		Expect(err).ToNot(HaveOccurred())
+
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		// Collect IP strings for easier comparison
+		ipStrings := make([]string, len(x509Cert.IPAddresses))
+		for i, ip := range x509Cert.IPAddresses {
+			ipStrings[i] = ip.String()
+		}
+
+		// Should include the pod IP
+		Expect(ipStrings).To(ContainElement("10.244.0.5"))
+		// Should still include localhost IP
+		Expect(ipStrings).To(ContainElement("127.0.0.1"))
+	})
+
+	t.Run("includes IP-based pod DNS when POD_IP and POD_NAMESPACE are set", func(t *testing.T) {
+		os.Setenv("POD_IP", "10.244.0.5")
+		os.Setenv("POD_NAMESPACE", "default")
+		defer func() {
+			os.Unsetenv("POD_IP")
+			os.Unsetenv("POD_NAMESPACE")
+		}()
+
+		cert, err := generateSelfSignedCert()
+		Expect(err).ToNot(HaveOccurred())
+
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		// Should include IP-based pod DNS (Kubernetes standard format)
+		Expect(x509Cert.DNSNames).To(ContainElement("10-244-0-5.default.pod.cluster.local"))
+		// Should still include localhost
+		Expect(x509Cert.DNSNames).To(ContainElement("localhost"))
+	})
+
+	t.Run("includes service DNS names when SERVICE_NAME and POD_NAMESPACE are set", func(t *testing.T) {
+		os.Setenv("SERVICE_NAME", "hostpath-metrics")
+		os.Setenv("POD_NAMESPACE", "default")
+		defer func() {
+			os.Unsetenv("SERVICE_NAME")
+			os.Unsetenv("POD_NAMESPACE")
+		}()
+
+		cert, err := generateSelfSignedCert()
+		Expect(err).ToNot(HaveOccurred())
+
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		// Should include service-based DNS names
+		Expect(x509Cert.DNSNames).To(ContainElement("hostpath-metrics"))
+		Expect(x509Cert.DNSNames).To(ContainElement("hostpath-metrics.default"))
+		Expect(x509Cert.DNSNames).To(ContainElement("hostpath-metrics.default.svc"))
+		Expect(x509Cert.DNSNames).To(ContainElement("hostpath-metrics.default.svc.cluster.local"))
+	})
+
+	t.Run("includes all SANs when all environment variables are set", func(t *testing.T) {
+		os.Setenv("POD_IP", "10.244.0.5")
+		os.Setenv("POD_NAMESPACE", "kube-system")
+		os.Setenv("SERVICE_NAME", "hostpath-metrics")
+		defer func() {
+			os.Unsetenv("POD_IP")
+			os.Unsetenv("POD_NAMESPACE")
+			os.Unsetenv("SERVICE_NAME")
+		}()
+
+		cert, err := generateSelfSignedCert()
+		Expect(err).ToNot(HaveOccurred())
+
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		// Collect IP strings for easier comparison
+		ipStrings := make([]string, len(x509Cert.IPAddresses))
+		for i, ip := range x509Cert.IPAddresses {
+			ipStrings[i] = ip.String()
+		}
+
+		// Verify IP addresses
+		Expect(ipStrings).To(ContainElement("127.0.0.1"))
+		Expect(ipStrings).To(ContainElement("10.244.0.5"))
+
+		// Verify DNS names include all variations
+		expectedDNSNames := []string{
+			"localhost",
+			// IP-based pod DNS (Kubernetes standard)
+			"10-244-0-5.kube-system.pod.cluster.local",
+			// Service DNS variations
+			"hostpath-metrics",
+			"hostpath-metrics.kube-system",
+			"hostpath-metrics.kube-system.svc",
+			"hostpath-metrics.kube-system.svc.cluster.local",
+		}
+		for _, dns := range expectedDNSNames {
+			Expect(x509Cert.DNSNames).To(ContainElement(dns))
+		}
+	})
+
+	t.Run("includes IPv6-based pod DNS when POD_IP is IPv6", func(t *testing.T) {
+		os.Setenv("POD_IP", "2001:db8::1")
+		os.Setenv("POD_NAMESPACE", "default")
+		defer func() {
+			os.Unsetenv("POD_IP")
+			os.Unsetenv("POD_NAMESPACE")
+		}()
+
+		cert, err := generateSelfSignedCert()
+		Expect(err).ToNot(HaveOccurred())
+
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		// Collect IP strings for easier comparison
+		ipStrings := make([]string, len(x509Cert.IPAddresses))
+		for i, ip := range x509Cert.IPAddresses {
+			ipStrings[i] = ip.String()
+		}
+
+		// Should include the IPv6 address
+		Expect(ipStrings).To(ContainElement("2001:db8::1"))
+
+		// Should include IPv6-based pod DNS (colons replaced with dashes)
+		Expect(x509Cert.DNSNames).To(ContainElement("2001-db8--1.default.pod.cluster.local"))
+	})
+
+	t.Run("handles invalid POD_IP gracefully", func(t *testing.T) {
+		os.Setenv("POD_IP", "invalid-ip")
+		defer os.Unsetenv("POD_IP")
+
+		// Should still succeed, just skip the invalid IP
+		cert, err := generateSelfSignedCert()
+		Expect(err).ToNot(HaveOccurred())
+
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		// Should only have localhost IP, not the invalid one
+		Expect(x509Cert.IPAddresses).To(HaveLen(1))
+		Expect(x509Cert.IPAddresses[0].String()).To(Equal("127.0.0.1"))
+	})
+}
+
+func Test_getTLSVersion(t *testing.T) {
+	RegisterTestingT(t)
+
+	tests := []struct {
+		name         string
+		versionName  string
+		wantVersion  *uint16
+		wantNil      bool
+	}{
+		{
+			name:        "VersionTLS10",
+			versionName: "VersionTLS10",
+			wantVersion: func() *uint16 { v := uint16(tls.VersionTLS10); return &v }(),
+		},
+		{
+			name:        "VersionTLS11",
+			versionName: "VersionTLS11",
+			wantVersion: func() *uint16 { v := uint16(tls.VersionTLS11); return &v }(),
+		},
+		{
+			name:        "VersionTLS12",
+			versionName: "VersionTLS12",
+			wantVersion: func() *uint16 { v := uint16(tls.VersionTLS12); return &v }(),
+		},
+		{
+			name:        "VersionTLS13",
+			versionName: "VersionTLS13",
+			wantVersion: func() *uint16 { v := uint16(tls.VersionTLS13); return &v }(),
+		},
+		{
+			name:        "invalid version string",
+			versionName: "InvalidVersion",
+			wantNil:     true,
+		},
+		{
+			name:        "empty string",
+			versionName: "",
+			wantNil:     true,
+		},
+		{
+			name:        "numeric version string",
+			versionName: "1.3",
+			wantNil:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getTLSVersion(tt.versionName)
+
+			if tt.wantNil {
+				Expect(result).To(BeNil(), "expected nil for version: %s", tt.versionName)
+			} else {
+				Expect(result).ToNot(BeNil(), "expected non-nil for version: %s", tt.versionName)
+				Expect(*result).To(Equal(*tt.wantVersion), "version mismatch for: %s", tt.versionName)
+			}
+		})
+	}
+}

--- a/pkg/hostpath/utils.go
+++ b/pkg/hostpath/utils.go
@@ -16,6 +16,7 @@ limitations under the License.
 package hostpath
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -170,22 +171,85 @@ func getStoragePoolDataDirectories(storagePoolInfo map[string]StoragePoolInfo) (
 	return directories, nil
 }
 
-// RunPrometheusServer runs a prometheus server for metrics
-func RunPrometheusServer(metricsAddr string) {
+// getTLSVersion converts a version string to a tls.Version constant.
+// Supported versions: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+// Returns nil if the version string is not recognized.
+func getTLSVersion(versionName string) *uint16 {
+	var versions = map[string]uint16{
+		"VersionTLS10": tls.VersionTLS10,
+		"VersionTLS11": tls.VersionTLS11,
+		"VersionTLS12": tls.VersionTLS12,
+		"VersionTLS13": tls.VersionTLS13,
+	}
+	if version, ok := versions[versionName]; ok {
+		return &version
+	}
+
+	return nil
+}
+
+// RunPrometheusServer runs a prometheus server for metrics with TLS support.
+// If certFile and keyFile are provided, they will be used for TLS.
+// Otherwise, a self-signed certificate will be generated automatically.
+// tlsVersion should be "VersionTLS10", "VersionTLS11", "VersionTLS12", or "VersionTLS13" (default: "VersionTLS13").
+func RunPrometheusServer(metricsAddr, certFile, keyFile, tlsVersion string) {
 	err := metrics.SetupMetrics()
 	if err != nil {
 		klog.Error(err, "Failed to Setup Prometheus metrics")
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
-	server := http.Server{
+
+	server := &http.Server{
 		Addr:    metricsAddr,
 		Handler: mux,
 	}
 
-	go func() {
-		err := server.ListenAndServe()
+	// Validate certificate configuration
+	certProvided := certFile != ""
+	keyProvided := keyFile != ""
+	if certProvided != keyProvided {
+		klog.Warningf("Partial TLS certificate configuration: cert=%q, key=%q. Both --metrics-cert-file and --metrics-key-file must be provided together. Falling back to self-signed certificate.", certFile, keyFile)
+	}
+
+	// Parse TLS version (maps string name to crypto/tls MinVersion constant)
+	minTLSVersion := getTLSVersion(tlsVersion)
+	if minTLSVersion == nil {
+		klog.Warningf("Invalid TLS version '%s', defaulting to TLS 1.3", tlsVersion)
+		defaultVersion := uint16(tls.VersionTLS13)
+		minTLSVersion = &defaultVersion
+	}
+
+	// Configure TLS
+	tlsConfig := &tls.Config{
+		MinVersion: *minTLSVersion,
+	}
+
+	// If cert and key files are provided, use them
+	if certProvided && keyProvided {
+		klog.V(1).Infof("Using provided certificates for metrics server: cert=%s, key=%s", certFile, keyFile)
+		server.TLSConfig = tlsConfig
+	} else {
+		// Generate self-signed certificate
+		klog.V(1).Info("Generating self-signed certificate for metrics server")
+		cert, err := generateSelfSignedCert()
 		if err != nil {
+			klog.Error(err, "Failed to generate self-signed certificate for metrics server")
+			return
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+		server.TLSConfig = tlsConfig
+	}
+
+	go func() {
+		var err error
+		if certProvided && keyProvided {
+			err = server.ListenAndServeTLS(certFile, keyFile)
+		} else {
+			// Use the self-signed cert from TLSConfig
+			err = server.ListenAndServeTLS("", "")
+		}
+		if err != nil && err != http.ErrServerClosed {
 			klog.Error(err, "Failed to start Prometheus metrics endpoint server")
 		}
 	}()

--- a/tests/pvc_test.go
+++ b/tests/pvc_test.go
@@ -313,7 +313,7 @@ func createPodUsingPVCWithCommand(namespace, name string, pvc *corev1.Persistent
 			Containers: []corev1.Container{
 				{
 					Name:    "runner",
-					Image:   "quay.io/kubevirt/cdi-importer:latest",
+					Image:   "quay.io/kubevirt/cdi-importer:latest-amd64",
 					Command: []string{"/bin/sh", "-c", command},
 					VolumeMounts: []v1.VolumeMount{
 						{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added optional parameters to configure the TLS on the metrics server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add TLS for metrics on controller
```

