### PR TITLE
tests: add HPPSharingPoolPathWithOS alert firing test

### DIFF
--- a/tests/prometheus_test.go
+++ b/tests/prometheus_test.go
@@ -157,6 +157,16 @@ func TestPrometheusAlerts(t *testing.T) {
 		testPrometheusRule(token, hppCRReadyQueryName, promRuleCRReady)
 	})
 
+	t.Run("HPPSharingPoolPathWithOS", func(t *testing.T) {
+		backingStorage := os.Getenv("KUBEVIRT_STORAGE")
+		hppCrType := os.Getenv("HPP_CR_TYPE")
+		if backingStorage == "rook-ceph-default" && hppCrType == "storagepool-pvc-template" {
+			t.Skip("HPP pool is not shared with OS in this CI config")
+		}
+
+		testPrometheusAlert("HPPSharingPoolPathWithOS", token, t)
+	})
+
 	_ = scaleOperatorUp(k8sClient)
 	updateHPPWithRetry(hppClient, "hostpath-provisioner", func(hpp *hostpathprovisionerv1.HostPathProvisioner) {
 		hpp.Spec = *oldSpec


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add a subtest that verifies the
HPPSharingPoolPathWithOS alert fires
correctly. Skips in CI configs where the
pool is not shared with the OS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://redhat.atlassian.net/browse/CNV-54880

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: Cursor <cursoragent@cursor.com>