### PR TITLE
deploy operator by release version

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -68,14 +68,17 @@ EOF
 
 fi
 
+OPERATOR_URL=$(resolve_operator_url)
+echo "Using operator URL: ${OPERATOR_URL}"
+
 if [ ${HPP_NAMESPACE} == "hostpath-provisioner" ]; then
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/namespace.yaml
+_kubectl apply -f ${OPERATOR_URL}/namespace.yaml
 fi
 _kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
 _kubectl wait --for=condition=available -n cert-manager --timeout=120s --all deployments
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/webhook.yaml -n hostpath-provisioner
+_kubectl apply -f ${OPERATOR_URL}/webhook.yaml -n hostpath-provisioner
 echo "Deploying"
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/operator.yaml -n ${HPP_NAMESPACE}
+_kubectl apply -f ${OPERATOR_URL}/operator.yaml -n ${HPP_NAMESPACE}
 
 echo "Waiting for it to be ready"
 _kubectl rollout status -n hostpath-provisioner deployment/hostpath-provisioner-operator --timeout=120s
@@ -86,14 +89,14 @@ _kubectl get pods -n hostpath-provisioner
 _kubectl patch deployment hostpath-provisioner-operator -n hostpath-provisioner --patch-file cluster-sync/patch.yaml
 
 _kubectl rollout status -n hostpath-provisioner deployment/hostpath-provisioner-operator --timeout=120s
-HPP_CR_PATH="https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/hostpathprovisioner_legacy_cr.yaml"
-HPP_CSI_SC="https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/storageclass-wffc-legacy-csi.yaml"
+HPP_CR_PATH="${OPERATOR_URL}/hostpathprovisioner_legacy_cr.yaml"
+HPP_CSI_SC="${OPERATOR_URL}/storageclass-wffc-legacy-csi.yaml"
 if [ "${KUBEVIRT_STORAGE}" == "rook-ceph-default" ] && [ "${HPP_CR_TYPE}" == "storagepool-pvc-template" ]; then
   HPP_CR_PATH="deploy/tests/hostpathprovisioner_ceph_pvc_pool_cr.yaml"
   HPP_CSI_SC="deploy/tests/storageclass_wffc_ceph_pool.yaml"
 fi
 _kubectl apply -f $HPP_CR_PATH
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/storageclass-wffc-legacy.yaml
+_kubectl apply -f ${OPERATOR_URL}/storageclass-wffc-legacy.yaml
 _kubectl apply -f $HPP_CSI_SC
 
 cat <<EOF | _kubectl apply -f -

--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -15,6 +15,31 @@ if [ -z "$KUBEVIRTCI_CONFIG_PATH" ]; then
     )"
 fi
 
+# operator image tags are only set in the release dowload manifest
+OPERATOR_REPO="https://github.com/kubevirt/hostpath-provisioner-operator"
+
+function resolve_operator_url() {
+    if [ -n "${OPERATOR_VERSION}" ]; then
+        echo "${OPERATOR_REPO}/releases/download/${OPERATOR_VERSION}"
+        return
+    fi
+    # PULL_BASE_REF is set for prow jobs, get correct tag if targetting release branch
+    if [ -n "${PULL_BASE_REF}" ] && [[ "${PULL_BASE_REF}" == release-* ]]; then
+        local tag=$(git describe --tags --abbrev=0 2>/dev/null)
+        if [ -z "${tag}" ]; then
+        echo "ERROR: on release branch but no git tags found" >&2
+        exit 1
+        fi
+        echo "${OPERATOR_REPO}/releases/download/${tag}"
+        return
+    fi
+    # for local enviornments or when prow is targetting main, fall back to using main
+    # NOTE: if you are working off a release branch, this could cause issues
+    # instead you should explicitly set the OPERATOR_VERSION
+    echo "https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy"
+}
+
+
 
 KUBEVIRTCI_CLUSTER_PATH=${KUBEVIRTCI_CLUSTER_PATH:-${KUBEVIRTCI_PATH}/cluster}
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.32}

--- a/hack/k8s-e2e.sh
+++ b/hack/k8s-e2e.sh
@@ -64,13 +64,16 @@ DOCKER_REPO=${registry} make manifest manifest-push
 
 TEST_DRIVER=./hack/test-driver.yaml
 
+OPERATOR_URL=$(resolve_operator_url)
+echo "Using operator URL: ${OPERATOR_URL}"
+
 #install hpp
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/namespace.yaml
+_kubectl apply -f ${OPERATOR_URL}/namespace.yaml
 _kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
 _kubectl wait --for=condition=available -n cert-manager --timeout=120s --all deployments
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/webhook.yaml -n hostpath-provisioner
+_kubectl apply -f ${OPERATOR_URL}/webhook.yaml -n hostpath-provisioner
 echo "Deploying"
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/operator.yaml -n hostpath-provisioner
+_kubectl apply -f ${OPERATOR_URL}/operator.yaml -n hostpath-provisioner
 
 echo "Waiting for it to be ready"
 _kubectl rollout status -n hostpath-provisioner deployment/hostpath-provisioner-operator --timeout=120s
@@ -90,13 +93,13 @@ if [ "${HPP_CR_TYPE}" == "overlay-csi" ]; then
   _kubectl apply -f deploy/snapshot/setup-snapshot-controller.yaml
 
   # deploy custom hpp cr and volumesnapshot class that enables overlay-csi and snapshot/restore
-  _kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/hostpathprovisioner_overlay_csi_cr.yaml
-  _kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/volumesnapshotclass.yaml
+  _kubectl apply -f ${OPERATOR_URL}/hostpathprovisioner_overlay_csi_cr.yaml
+  _kubectl apply -f ${OPERATOR_URL}/volumesnapshotclass.yaml
   TEST_DRIVER=./hack/test-driver-overlay.yaml
-else 
-  _kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/hostpathprovisioner_legacy_cr.yaml
+else
+  _kubectl apply -f ${OPERATOR_URL}/hostpathprovisioner_legacy_cr.yaml
 fi
-_kubectl apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/storageclass-wffc-legacy-csi.yaml
+_kubectl apply -f ${OPERATOR_URL}/storageclass-wffc-legacy-csi.yaml
 #Wait for hpp to be available.
 _kubectl wait hostpathprovisioners.hostpathprovisioner.kubevirt.io/hostpath-provisioner --for=condition=Available --timeout=480s
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently sync.sh and test.sh always deploy the operator yamls from the main branch which can lead to image version mismatches.

Instead we should deploy the operator resources from associated release version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
deploy operator by release version
```

