### PR TITLE
fix image caching error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,13 @@ image-csi: hostpath-csi-driver
 	buildah build $(BUILDAH_PLATFORM_FLAG) -t $(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(GOARCH) -f Dockerfile.csi .
 
 manifest-controller: image-controller
-	-buildah manifest create $(DOCKER_REPO)/$(HPP_IMAGE):local
+	-buildah manifest rm $(DOCKER_REPO)/$(HPP_IMAGE):local
+	buildah manifest create $(DOCKER_REPO)/$(HPP_IMAGE):local
 	buildah manifest add --arch $(GOARCH) $(DOCKER_REPO)/$(HPP_IMAGE):local containers-storage:$(DOCKER_REPO)/$(HPP_IMAGE):$(GOARCH)
 
 manifest-csi: image-csi
-	-buildah manifest create $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local
+	-buildah manifest rm $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local
+	buildah manifest create $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local
 	buildah manifest add --arch $(GOARCH) $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local containers-storage:$(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(GOARCH)
 
 push-csi:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When running consecutive `make cluster-sync`  buildah will attempt to re-create local images with names that are already in use. Throwing error ```Error: image name "localhost:37883/hostpath-csi-driver:local" is already associated with image "f10f3fe1e406d61ed994cbb67016d07a1bf9e29b173859067302eb8b331722d1": that name is already in use```

This change will delete the previous local image so consecutive syncs won't fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix image caching error
```

