### PR TITLE
Fix latest only containing s390x container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,13 +54,21 @@ image-csi: hostpath-csi-driver
 	buildah build $(BUILDAH_PLATFORM_FLAG) -t $(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(GOARCH) -f Dockerfile.csi .
 
 manifest-controller: image-controller
-	-buildah manifest rm $(DOCKER_REPO)/$(HPP_IMAGE):local
-	buildah manifest create $(DOCKER_REPO)/$(HPP_IMAGE):local
+	@manifest="$(DOCKER_REPO)/$(HPP_IMAGE):local"; \
+	if ! buildah manifest inspect "$$manifest" >/dev/null 2>&1; then \
+		buildah manifest rm "$$manifest" 2>/dev/null || true; \
+		buildah rmi -f "$$manifest" 2>/dev/null || true; \
+		buildah manifest create "$$manifest"; \
+	fi
 	buildah manifest add --arch $(GOARCH) $(DOCKER_REPO)/$(HPP_IMAGE):local containers-storage:$(DOCKER_REPO)/$(HPP_IMAGE):$(GOARCH)
 
 manifest-csi: image-csi
-	-buildah manifest rm $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local
-	buildah manifest create $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local
+	@manifest="$(DOCKER_REPO)/$(HPP_CSI_IMAGE):local"; \
+	if ! buildah manifest inspect "$$manifest" >/dev/null 2>&1; then \
+		buildah manifest rm "$$manifest" 2>/dev/null || true; \
+		buildah rmi -f "$$manifest" 2>/dev/null || true; \
+		buildah manifest create "$$manifest"; \
+	fi
 	buildah manifest add --arch $(GOARCH) $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local containers-storage:$(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(GOARCH)
 
 push-csi:
@@ -74,7 +82,9 @@ clean: manifest-clean
 
 manifest-clean:
 	-buildah manifest rm $(DOCKER_REPO)/$(HPP_IMAGE):local
+	-buildah rmi -f $(DOCKER_REPO)/$(HPP_IMAGE):local
 	-buildah manifest rm $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local
+	-buildah rmi -f $(DOCKER_REPO)/$(HPP_CSI_IMAGE):local
 
 build: clean hostpath-provisioner hostpath-csi-driver
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The fix in #524 fixed a local build error that would generate an error that looks like this: 
```Error: image name "localhost:37883/hostpath-csi-driver:local" s already associated with image "f10f3fe1e406d61ed994cbb67016d07a1bf9e29b173859067302eb8b331722d1": that name is already in use```

But it inadvertently broke the release process by always removing all the intermediate images this caused the latest tag to only have s390x since that is the last architecture to be built.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

