### PR TITLE
Avoid emulated glibc installation for non-amd64 cross builds

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,4 +1,5 @@
 FROM registry.fedoraproject.org/fedora-minimal:42
-RUN microdnf install glibc -y
+ARG TARGETARCH
+RUN if [ "${TARGETARCH}" = "amd64" ]; then microdnf install glibc -y; fi
 COPY _out/hostpath-provisioner /
 CMD ["/hostpath-provisioner"]

--- a/Dockerfile.csi
+++ b/Dockerfile.csi
@@ -1,5 +1,6 @@
 FROM registry.fedoraproject.org/fedora-minimal:42
-RUN microdnf install glibc -y
+ARG TARGETARCH
+RUN if [ "${TARGETARCH}" = "amd64" ]; then microdnf install glibc -y; fi
 COPY _out/hostpath-csi-driver /
 ENTRYPOINT ["/hostpath-csi-driver"]
 

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,10 @@ manifest: manifest-controller manifest-csi
 manifest-push: push-csi push-controller
 
 image-controller: hostpath-provisioner
-	buildah build $(BUILDAH_PLATFORM_FLAG) -t $(DOCKER_REPO)/$(HPP_IMAGE):$(GOARCH) -f Dockerfile.controller .
+	buildah build $(BUILDAH_PLATFORM_FLAG) --build-arg TARGETARCH=$(GOARCH) -t $(DOCKER_REPO)/$(HPP_IMAGE):$(GOARCH) -f Dockerfile.controller .
 
 image-csi: hostpath-csi-driver
-	buildah build $(BUILDAH_PLATFORM_FLAG) -t $(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(GOARCH) -f Dockerfile.csi .
+	buildah build $(BUILDAH_PLATFORM_FLAG) --build-arg TARGETARCH=$(GOARCH) -t $(DOCKER_REPO)/$(HPP_CSI_IMAGE):$(GOARCH) -f Dockerfile.csi .
 
 manifest-controller: image-controller
 	@manifest="$(DOCKER_REPO)/$(HPP_IMAGE):local"; \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
glibc is only needed for amd64 (CGO_ENABLED=1 with strictfipsruntime).
Non-amd64 builds produce static binaries (CGO_ENABLED=0) and don't
need it. Conditionally install glibc based on TARGETARCH to skip the
expensive microdnf operation under QEMU emulation for arm64/s390x.

This should significantly cut down the release job time.
See: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/push-release-hostpath-provisioner-images/2068667040889049088

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Maintenance: cut down build times for cross arch builds
```

