### PR TITLE
Add e2e test verifying readOnlyRootFilesystem on operator deployment

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -471,3 +471,41 @@ func Test_CSIDriver(t *testing.T) {
 		verifyCsiDriver(k8sClient)
 	})
 }
+
+func TestOperatorSecurityContext(t *testing.T) {
+	RegisterTestingT(t)
+	tearDown, k8sClient := setupTestCase(t)
+	defer tearDown(t)
+
+	t.Run("operator should have readOnlyRootFilesystem", func(t *testing.T) {
+		RegisterTestingT(t)
+		deployment, err := k8sClient.AppsV1().Deployments(namespace).Get(
+			context.TODO(), operatorDeploymentName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, c := range deployment.Spec.Template.Spec.Containers {
+			Expect(c.SecurityContext).ToNot(BeNil(),
+				"container %s should have SecurityContext", c.Name)
+			Expect(c.SecurityContext.ReadOnlyRootFilesystem).ToNot(BeNil(),
+				"container %s should have ReadOnlyRootFilesystem set", c.Name)
+			Expect(*c.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue(),
+				"container %s should have ReadOnlyRootFilesystem=true", c.Name)
+		}
+	})
+
+	t.Run("CSI privileged containers should NOT have readOnlyRootFilesystem", func(t *testing.T) {
+		RegisterTestingT(t)
+		ds, err := k8sClient.AppsV1().DaemonSets(namespace).Get(
+			context.TODO(), dsCsiName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, c := range ds.Spec.Template.Spec.Containers {
+			if c.SecurityContext != nil &&
+				c.SecurityContext.Privileged != nil &&
+				*c.SecurityContext.Privileged {
+				Expect(c.SecurityContext.ReadOnlyRootFilesystem).To(BeNil(),
+					"privileged container %s should not set readOnlyRootFilesystem", c.Name)
+			}
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds an e2e test (`TestOperatorSecurityContext`) that verifies:

- The `hostpath-provisioner-operator` deployment has readOnlyRootFilesystem: true on all its containers
- The CSI DaemonSet privileged containers do NOT have readOnlyRootFilesystem set

This complements the[ production change in kubevirt/hostpath-provisioner-operator](https://github.com/kubevirt/hostpath-provisioner-operator/pull/741) that enables readOnlyRootFilesystem on the operator container.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The corresponding production fix is in [kubevirt/hostpath-provisioner-operator](https://github.com/kubevirt/hostpath-provisioner-operator/pull/741) (adds readOnlyRootFilesystem: true to deploy/operator.yaml). This PR only adds the e2e verification.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add e2e test verifying readOnlyRootFilesystem on operator deployment
```

