### PR TITLE
Update cert-manager to 1.22.1

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -74,8 +74,8 @@ echo "Using operator URL: ${OPERATOR_URL}"
 if [ ${HPP_NAMESPACE} == "hostpath-provisioner" ]; then
 _kubectl apply -f ${OPERATOR_URL}/namespace.yaml
 fi
-_kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
-_kubectl wait --for=condition=available -n cert-manager --timeout=120s --all deployments
+_kubectl apply -f "${CERT_MANAGER_MANIFEST_URL}"
+_kubectl wait --for=condition=available -n cert-manager --timeout=180s --all deployments
 _kubectl apply -f ${OPERATOR_URL}/webhook.yaml -n hostpath-provisioner
 echo "Deploying"
 _kubectl apply -f ${OPERATOR_URL}/operator.yaml -n ${HPP_NAMESPACE}
@@ -90,8 +90,7 @@ _kubectl patch deployment hostpath-provisioner-operator -n hostpath-provisioner 
 
 _kubectl rollout status -n hostpath-provisioner deployment/hostpath-provisioner-operator --timeout=120s
 
-# allow for the webhook server to be ready
-sleep 5
+wait_for_operator_webhook
 
 HPP_CR_PATH="${OPERATOR_URL}/hostpathprovisioner_legacy_cr.yaml"
 HPP_CSI_SC="${OPERATOR_URL}/storageclass-wffc-legacy-csi.yaml"
@@ -102,7 +101,7 @@ elif [ "${HPP_CR_TYPE}" == "overlay-csi" ]; then
   HPP_CR_PATH="deploy/tests/hostpathprovisioner_nfs_overlay_cr.yaml"
   HPP_CSI_SC="deploy/tests/storageclass_wffc_nfs_overlay.yaml"
 fi
-_kubectl apply -f $HPP_CR_PATH
+retry_kubectl_apply "$HPP_CR_PATH"
 _kubectl apply -f ${OPERATOR_URL}/storageclass-wffc-legacy.yaml
 _kubectl apply -f $HPP_CSI_SC
 

--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -40,7 +40,35 @@ function resolve_operator_url() {
     echo "https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy"
 }
 
+CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-v1.21.1}
+CERT_MANAGER_MANIFEST_URL="https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
 
+function wait_for_operator_webhook() {
+    local namespace="${1:-hostpath-provisioner}"
+    echo "Waiting for webhook certificate"
+    _kubectl wait --for=condition=Ready \
+        certificate/hostpath-provisioner-operator-webhook-service-cert \
+        -n "${namespace}" --timeout=180s
+}
+
+function retry_kubectl_apply() {
+    local manifest="$1"
+    local max_attempts="${2:-12}"
+    local wait_seconds="${3:-10}"
+    local attempt=1
+
+    while [ "$attempt" -le "$max_attempts" ]; do
+        if _kubectl apply -f "$manifest"; then
+            return 0
+        fi
+        echo "Attempt ${attempt}/${max_attempts} failed applying ${manifest}, retrying in ${wait_seconds}s..."
+        sleep "$wait_seconds"
+        attempt=$((attempt + 1))
+    done
+
+    echo "ERROR: failed to apply ${manifest} after ${max_attempts} attempts"
+    return 1
+}
 
 KUBEVIRTCI_CLUSTER_PATH=${KUBEVIRTCI_CLUSTER_PATH:-${KUBEVIRTCI_PATH}/cluster}
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.34}

--- a/hack/k8s-e2e.sh
+++ b/hack/k8s-e2e.sh
@@ -69,8 +69,8 @@ echo "Using operator URL: ${OPERATOR_URL}"
 
 #install hpp
 _kubectl apply -f ${OPERATOR_URL}/namespace.yaml
-_kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
-_kubectl wait --for=condition=available -n cert-manager --timeout=120s --all deployments
+_kubectl apply -f "${CERT_MANAGER_MANIFEST_URL}"
+_kubectl wait --for=condition=available -n cert-manager --timeout=180s --all deployments
 _kubectl apply -f ${OPERATOR_URL}/webhook.yaml -n hostpath-provisioner
 echo "Deploying"
 _kubectl apply -f ${OPERATOR_URL}/operator.yaml -n hostpath-provisioner
@@ -84,6 +84,7 @@ _kubectl get pods -n hostpath-provisioner
 _kubectl patch deployment hostpath-provisioner-operator -n hostpath-provisioner --patch-file cluster-sync/patch.yaml
 _kubectl rollout status -n hostpath-provisioner deployment/hostpath-provisioner-operator --timeout=120s
 _kubectl wait --for=condition=available deployment -n hostpath-provisioner hostpath-provisioner-operator
+wait_for_operator_webhook
 if [ "${HPP_CR_TYPE}" == "overlay-csi" ]; then
   # deploy snapshot CRDs and controller
   _kubectl apply -f deploy/snapshot/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
@@ -93,11 +94,11 @@ if [ "${HPP_CR_TYPE}" == "overlay-csi" ]; then
   _kubectl apply -f deploy/snapshot/setup-snapshot-controller.yaml
 
   # deploy custom hpp cr and volumesnapshot class that enables overlay-csi and snapshot/restore
-  _kubectl apply -f ${OPERATOR_URL}/hostpathprovisioner_overlay_csi_cr.yaml
+  retry_kubectl_apply "${OPERATOR_URL}/hostpathprovisioner_overlay_csi_cr.yaml"
   _kubectl apply -f ${OPERATOR_URL}/volumesnapshotclass.yaml
   TEST_DRIVER=./hack/test-driver-overlay.yaml
 else
-  _kubectl apply -f ${OPERATOR_URL}/hostpathprovisioner_legacy_cr.yaml
+  retry_kubectl_apply "${OPERATOR_URL}/hostpathprovisioner_legacy_cr.yaml"
 fi
 _kubectl apply -f ${OPERATOR_URL}/storageclass-wffc-legacy-csi.yaml
 #Wait for hpp to be available.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update cert-manager to latest available version. Fix a race condition in deploying hostpath-provisioner. Do this by retrying creating the hostpath-provisioner CR. This is fixed in all CI lanes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

